### PR TITLE
Circumvent logback logstream autodetection from auditlog

### DIFF
--- a/src/yki/util/audit_log.clj
+++ b/src/yki/util/audit_log.clj
@@ -1,6 +1,7 @@
 (ns yki.util.audit-log
   (:require [clojure.tools.logging :as log]
-            [jsonista.core :as json])
+            [jsonista.core :as json]
+            [yki.util.log-util :as log-util])
   (:import [java.net InetAddress]
            [org.ietf.jgss Oid]
            [com.google.gson JsonParser]
@@ -69,7 +70,7 @@
           changes         (create-changes change)]
       (.log virkailija-logger user op target changes))
     (catch Exception e
-      (log/error e "Virkailija audit logging failed for data:" change))))
+      (log-util/error e "Virkailija audit logging failed for data:" change))))
 
 (defn log-participant
   [{:keys [request target-kv change oid]}]
@@ -86,4 +87,4 @@
           changes         (create-changes change)]
       (.log oppija-logger user op target changes))
     (catch Exception e
-      (log/error e "Participant audit logging failed for data:" change))))
+      (log-util/error e "Participant audit logging failed for data:" change))))

--- a/src/yki/util/log_util.clj
+++ b/src/yki/util/log_util.clj
@@ -1,0 +1,7 @@
+; THE ONLY REASON FOR THIS FILE IS TO CIRCUMVENT LOGBACK LOGSTREAM AUTODETECTION
+; USED ONLY FROM AUDIT LOG BECAUSE LOGBACK CAPTURES LOGGING CALLS TO ACTUAL AUDIT LOG
+(ns yki.util.log-util
+  (:require [clojure.tools.logging :as log]))
+
+(defn error [e error-text change]
+  (log/error e error-text change))


### PR DESCRIPTION
On error auditlog streamed the auditlog error to auditlog, when it was supposed
to be written to application log.