### PR TITLE
Adds exam session history endpoint and expands tests to include post admission registrations

### DIFF
--- a/src/yki/handler/exam_session.clj
+++ b/src/yki/handler/exam_session.clj
@@ -49,16 +49,11 @@
         (GET "/" []
           :query-params [{from :- ::ys/date nil} {days :- ::ys/days nil}]
           :return ::ys/exam-sessions-response
-          (log/info "----------------- HISTORY -------------")
-          (log/info "From: " from)
-          (log/info "Days: ", days)
-          ;"2040-04-21T00:00:00.000Z"
           (let [history-date (-> from
                                  (c/to-long)
                                  (c/from-long)
                                  (t/minus (t/days (if days days 180))))
                 string-date (f/unparse (f/formatter "yyyy-MM-dd") history-date)]
-            (log/info "New date: " string-date)
             (response {:exam_sessions (exam-session-db/get-exam-sessions db oid string-date)}))))
 
       (context "/:id" []

--- a/src/yki/handler/exam_session.clj
+++ b/src/yki/handler/exam_session.clj
@@ -12,6 +12,9 @@
             [ring.util.http-response :refer [conflict internal-server-error ok]]
             [ring.util.request]
             [yki.spec :as ys]
+            [clj-time.core :as t]
+            [clj-time.format :as f]
+            [clj-time.coerce :as c]
             [integrant.core :as ig]))
 
 (defn- send-to-queue [data-sync-q exam-session type]
@@ -42,6 +45,21 @@
                             :change {:type audit-log/create-op
                                      :new exam-session}})
             (response {:id exam-session-id}))))
+      (context "/history" []
+        (GET "/" []
+          :query-params [{from :- ::ys/date nil} {days :- ::ys/days nil}]
+          :return ::ys/exam-sessions-response
+          (log/info "----------------- HISTORY -------------")
+          (log/info "From: " from)
+          (log/info "Days: ", days)
+          ;"2040-04-21T00:00:00.000Z"
+          (let [history-date (-> from
+                                 (c/to-long)
+                                 (c/from-long)
+                                 (t/minus (t/days (if days days 180))))
+                string-date (f/unparse (f/formatter "yyyy-MM-dd") history-date)]
+            (log/info "New date: " string-date)
+            (response {:exam_sessions (exam-session-db/get-exam-sessions db oid string-date)}))))
 
       (context "/:id" []
         (PUT "/" request
@@ -91,19 +109,19 @@
           :path-params [id :- ::ys/id]
           :body [post-admission ::ys/post-admission-update]
           :return ::ys/response
-            (if (exam-session-db/update-post-admission-details! db id post-admission)
-                (response {:success true})
-                (not-found {:success false
-                  :error "Exam session not found"})))
+          (if (exam-session-db/update-post-admission-details! db id post-admission)
+            (response {:success true})
+            (not-found {:success false
+                        :error "Exam session not found"})))
 
         (POST (str routing/post-admission-uri "/activation") request
-              :path-params [id :- ::ys/id]
-              :body [activation ::ys/post-admission-activation]
-              :return ::ys/response
-             (if (exam-session-db/set-post-admission-active! db (merge {:exam_session_id id} activation))
-                 (response {:success true})
-                 (not-found {:success false
-                  :error "Exam session not found"})))
+          :path-params [id :- ::ys/id]
+          :body [activation ::ys/post-admission-activation]
+          :return ::ys/response
+          (if (exam-session-db/set-post-admission-active! db (merge {:exam_session_id id} activation))
+            (response {:success true})
+            (not-found {:success false
+                        :error "Exam session not found"})))
         (context routing/registration-uri []
           (GET "/" {session :session}
             :path-params [id :- ::ys/id]

--- a/src/yki/spec.clj
+++ b/src/yki/spec.clj
@@ -109,6 +109,7 @@
 (s/def ::queue_full                 boolean?)
 (s/def ::queue                      int?)
 (s/def ::from                       ::date)
+(s/def ::days                       int?)
 ; post admission extensions for exam-session
 (s/def ::post_admission_quota      (s/nilable pos-int?))
 (s/def ::post_admission_start_date (s/nilable ::date))
@@ -233,21 +234,20 @@
 (s/def ::street_address ::non-blank-string)
 (s/def ::phone_number ::non-blank-string)
 
-
 (s/def ::registration (s/keys
-  :req-un [::first_name
-            ::last_name
-            ::nationalities
-            ::certificate_lang
-            ::exam_lang
-            (or ::birthdate ::ssn)
-            ::post_office
-            ::zip
-            ::street_address
-            ::phone_number
-            ::email]
-  :opt-un [::gender
-            ::nationality_desc]))
+                       :req-un [::first_name
+                                ::last_name
+                                ::nationalities
+                                ::certificate_lang
+                                ::exam_lang
+                                (or ::birthdate ::ssn)
+                                ::post_office
+                                ::zip
+                                ::street_address
+                                ::phone_number
+                                ::email]
+                       :opt-un [::gender
+                                ::nationality_desc]))
 
 (s/def ::registration-init (s/keys :req-un [::exam_session_id]))
 

--- a/test/resources/participants.json
+++ b/test/resources/participants.json
@@ -11,37 +11,64 @@
         "certificate_lang": "fi",
         "last_name": "Ankka",
         "first_name": "Iines",
-        "nationalities": ["246"],
+        "nationalities": [
+          "246"
+        ],
         "street_address": "Katu 4",
         "zip": "12346"
       },
-      "registration_id": 1,
-      "kind": "ADMISSION",
+      "original_exam_session_id": null,
       "order_number": null,
+      "kind": "ADMISSION",
       "state": "COMPLETED",
-      "original_exam_session_id": null
+      "registration_id": 1
     },
     {
       "form": {
         "post_office": "Ankkalinna",
+        "ssn": "201190-083N",
         "exam_lang": "fi",
         "phone_number": "+3584012345",
         "gender": "1",
         "email": "aa@al.fi",
         "certificate_lang": "fi",
-        "birthdate": "1999-01-01",
-        "ssn": "201190-083N",
         "last_name": "Ankka",
         "first_name": "Aku",
-        "nationalities": ["180"],
+        "birthdate": "1999-01-01",
+        "nationalities": [
+          "180"
+        ],
         "street_address": "Katu 3",
         "zip": "12345"
       },
-      "registration_id": 2,
-      "kind": "ADMISSION",
+      "original_exam_session_id": null,
       "order_number": null,
+      "kind": "ADMISSION",
       "state": "COMPLETED",
-      "original_exam_session_id": null
+      "registration_id": 2
+    },
+    {
+      "form": {
+        "post_office": "Ankkalinna",
+        "ssn": "301079-083N",
+        "exam_lang": "fi",
+        "phone_number": "+3584012347",
+        "gender": null,
+        "email": "roope@al.fi",
+        "certificate_lang": "fi",
+        "last_name": "Ankka",
+        "first_name": "Roope",
+        "nationalities": [
+          "246"
+        ],
+        "street_address": "Katu 5",
+        "zip": "12346"
+      },
+      "original_exam_session_id": null,
+      "order_number": null,
+      "kind": "POST_ADMISSION",
+      "state": "COMPLETED",
+      "registration_id": 3
     },
     {
       "form": {
@@ -54,7 +81,9 @@
         "certificate_lang": "fi",
         "last_name": "Ankka",
         "first_name": "Iines",
-        "nationalities": ["246"],
+        "nationalities": [
+          "246"
+        ],
         "street_address": "Katu 4",
         "zip": "12346"
       },
@@ -62,7 +91,7 @@
       "order_number": "order1234",
       "kind": "ADMISSION",
       "state": "EXPIRED",
-      "registration_id": 3
+      "registration_id": 4
     }
   ]
 }

--- a/test/yki/boundary/yki_register_test.clj
+++ b/test/yki/boundary/yki_register_test.clj
@@ -73,7 +73,7 @@
             delete-exam-session-res (yki-register/sync-exam-session-and-organizer db url-helper {:user "user" :password "pass"} false delete-exam-session-req)]
         "tests that exception is not thrown"))))
 
-(def csv (s/join (System/lineSeparator) ["5.4.3.2.2;301079-122F;Ankka;Iines;N;FIN;Katu 4;12346;Ankkalinna;aa@al.fi;fi;fi" "5.4.3.2.1;201190-083N;Ankka;Aku;M;xxx;Katu 3;12345;Ankkalinna;aa@al.fi;fi;fi" "5.4.3.2.3;301079-083N;Ankka;Roope;M;FIN;Katu 5;12346;Ankkalinna;roope@al.fi;fi;fi"]))
+(def csv (s/join (System/lineSeparator) ["5.4.3.2.2;301079-122F;Ankka;Iines;N;FIN;Katu 4;12346;Ankkalinna;aa@al.fi;fi;fi" "5.4.3.2.1;201190-083N;Ankka;Aku;M;xxx;Katu 3;12345;Ankkalinna;aa@al.fi;fi;fi" "5.4.3.2.4;301079-083N;Ankka;Roope;M;FIN;Katu 5;12346;Ankkalinna;roope@al.fi;fi;fi"]))
 
 (deftest sync-exam-session-participants-test
   (base/insert-base-data)

--- a/test/yki/boundary/yki_register_test.clj
+++ b/test/yki/boundary/yki_register_test.clj
@@ -73,7 +73,7 @@
             delete-exam-session-res (yki-register/sync-exam-session-and-organizer db url-helper {:user "user" :password "pass"} false delete-exam-session-req)]
         "tests that exception is not thrown"))))
 
-(def csv (s/join (System/lineSeparator) ["5.4.3.2.2;301079-122F;Ankka;Iines;N;FIN;Katu 4;12346;Ankkalinna;aa@al.fi;fi;fi" "5.4.3.2.1;201190-083N;Ankka;Aku;M;xxx;Katu 3;12345;Ankkalinna;aa@al.fi;fi;fi"]))
+(def csv (s/join (System/lineSeparator) ["5.4.3.2.2;301079-122F;Ankka;Iines;N;FIN;Katu 4;12346;Ankkalinna;aa@al.fi;fi;fi" "5.4.3.2.1;201190-083N;Ankka;Aku;M;xxx;Katu 3;12345;Ankkalinna;aa@al.fi;fi;fi" "5.4.3.2.3;301079-083N;Ankka;Roope;M;FIN;Katu 5;12346;Ankkalinna;roope@al.fi;fi;fi"]))
 
 (deftest sync-exam-session-participants-test
   (base/insert-base-data)

--- a/test/yki/handler/base_test.clj
+++ b/test/yki/handler/base_test.clj
@@ -189,9 +189,16 @@
 (defn insert-exam-dates []
   (jdbc/execute! @embedded-db/conn "INSERT INTO exam_date(exam_date, registration_start_date, registration_end_date) VALUES ('2039-05-02', '2039-01-01', '2039-03-01')"))
 
+(defn insert-exam-history-dates [exam-date reg-start reg-end]
+  (println "INSERT EXAM HISTORY DATES: " exam-date reg-start reg-end)
+  (jdbc/execute! @embedded-db/conn (str "INSERT INTO exam_date(exam_date, registration_start_date, registration_end_date) VALUES ('" exam-date "', '" reg-start "', '" reg-end "')")))
+
 (def select-participant "(SELECT id from participant WHERE external_user_id = 'test@user.com')")
 
 (def select-exam-session "(SELECT id from exam_session WHERE max_participants = 5)")
+
+(defn select-exam-date-by-date [exam-date]
+  (str "(SELECT id from exam_date WHERE exam_date='" exam-date "')"))
 
 (defn insert-exam-session
   [exam-date-id oid count]
@@ -244,6 +251,24 @@
         'Other info',
         '" lang "',
         (SELECT id FROM exam_session where organizer_id =  (SELECT id FROM organizer where oid = " oid ") ))")))
+
+(defn insert-exam-session-location-by-date
+  [exam-date lang]
+  (jdbc/execute! @embedded-db/conn (str "INSERT INTO exam_session_location (name,
+    street_address,
+    post_office,
+    zip,
+    other_location_info,
+    lang,
+    exam_session_id)
+      VALUES (
+        'Omenia',
+        'Upseerinkatu 11',
+        'Espoo',
+        '00240',
+        'Other info',
+        '" lang "',
+        (SELECT id FROM exam_session where exam_date_id =(SELECT id from exam_date WHERE exam_date='" exam-date "')))")))
 
 (defn insert-base-data []
   (insert-organizer "'1.2.3.4'")

--- a/test/yki/handler/base_test.clj
+++ b/test/yki/handler/base_test.clj
@@ -20,6 +20,9 @@
             [yki.middleware.no-auth]
             [yki.handler.registration]
             [yki.util.url-helper]
+            [yki.util.common :as c]
+            [clj-time.format :as f]
+            [clj-time.core :as t]
             [yki.handler.organizer]))
 
 (def code-ok "4ce84260-3d04-445e-b914-38e93c1ef667")
@@ -67,6 +70,17 @@
 
 (def post-admission-deactivation
   (slurp "test/resources/post_admission_deactivation.json"))
+
+(def date-formatter (f/formatter c/date-format))
+
+(defn yesterday []
+  (f/unparse (f/formatter c/date-format) (t/minus (t/now) (t/days 1))))
+
+(defn two-weeks-ago []
+  (f/unparse (f/formatter c/date-format) (t/minus (t/now) (t/days 14))))
+
+(defn two-weeks-from-now []
+  (f/unparse (f/formatter c/date-format) (t/plus (t/now) (t/days 14))))
 
 (defn change-entry
   [json-string key value]
@@ -171,6 +185,19 @@
                           :street_address "Katu 4"
                           :phone_number "+3584012346"})
 
+(def post-admission-registration-form {:first_name  "Roope"
+                                       :last_name  "Ankka"
+                                       :gender nil
+                                       :nationalities ["246"]
+                                       :ssn "301079-083N"
+                                       :certificate_lang "fi"
+                                       :exam_lang "fi"
+                                       :post_office "Ankkalinna"
+                                       :zip "12346"
+                                       :email "roope@al.fi"
+                                       :street_address "Katu 5"
+                                       :phone_number "+3584012347"})
+
 (defn insert-organizer [oid]
   (jdbc/execute! @embedded-db/conn (str "INSERT INTO organizer (oid, agreement_start_date, agreement_end_date, contact_name, contact_email, contact_phone_number, extra)
         VALUES (" oid ", '2018-01-01', '2089-01-01', 'name', 'email@oph.fi', 'phone', 'shared@oph.fi')")))
@@ -187,7 +214,8 @@
   (jdbc/execute! @embedded-db/conn (str "INSERT INTO attachment_metadata (external_id, organizer_id) values ('a0d5dfc2', (SELECT id FROM organizer WHERE oid = " oid " AND deleted_at IS NULL))")))
 
 (defn insert-exam-dates []
-  (jdbc/execute! @embedded-db/conn "INSERT INTO exam_date(exam_date, registration_start_date, registration_end_date) VALUES ('2039-05-02', '2039-01-01', '2039-03-01')"))
+  (jdbc/execute! @embedded-db/conn "INSERT INTO exam_date(exam_date, registration_start_date, registration_end_date) VALUES ('2039-05-02', '2039-01-01', '2039-03-01')")
+  (jdbc/execute! @embedded-db/conn "INSERT INTO exam_date(exam_date, registration_start_date, registration_end_date, post_admission_end_date) VALUES ('2039-05-10', '2039-01-01', '2039-03-01', '2039-04-15')"))
 
 (defn insert-exam-history-dates [exam-date reg-start reg-end]
   (jdbc/execute! @embedded-db/conn (str "INSERT INTO exam_date(exam_date, registration_start_date, registration_end_date) VALUES ('" exam-date "', '" reg-start "', '" reg-end "')")))
@@ -280,7 +308,8 @@
   (insert-exam-session-location "'1.2.3.4'" "sv")
   (insert-exam-session-location "'1.2.3.4'" "en")
   (jdbc/execute! @embedded-db/conn (str "INSERT INTO participant (external_user_id, email) VALUES ('test@user.com', 'test@user.com') "))
-  (jdbc/execute! @embedded-db/conn (str "INSERT INTO participant (external_user_id, email) VALUES ('anothertest@user.com', 'anothertest@user.com') ")))
+  (jdbc/execute! @embedded-db/conn (str "INSERT INTO participant (external_user_id, email) VALUES ('anothertest@user.com', 'anothertest@user.com') "))
+  (jdbc/execute! @embedded-db/conn (str "INSERT INTO participant (external_user_id, email) VALUES ('thirdtest@user.com', 'thirdtest@user.com') ")))
 
 (defn insert-payment []
   (jdbc/execute! @embedded-db/conn (str
@@ -294,7 +323,10 @@
     ('5.4.3.2.2', '" state "', " select-exam-session ", " select-participant ",'" (j/write-value-as-string registration-form-2) "')"))
   (jdbc/execute! @embedded-db/conn (str
                                     "INSERT INTO registration(person_oid, state, exam_session_id, participant_id, form) values
-                                    ('5.4.3.2.1','" state "', " select-exam-session ", " select-participant ",'" (j/write-value-as-string registration-form) "')")))
+                                    ('5.4.3.2.1','" state "', " select-exam-session ", " select-participant ",'" (j/write-value-as-string registration-form) "')"))
+  (jdbc/execute! @embedded-db/conn (str
+                                    "INSERT INTO registration(person_oid, state, exam_session_id, participant_id, form, kind) values
+                                    ('5.4.3.2.3','" state "', " select-exam-session ", " select-participant ",'" (j/write-value-as-string post-admission-registration-form) "', 'POST_ADMISSION')")))
 
 (defn insert-unpaid-expired-registration []
   (jdbc/execute! @embedded-db/conn (str
@@ -320,6 +352,29 @@
 
 (defn get-exam-session-id []
   (:id (select-one "SELECT id from exam_session WHERE max_participants = 5")))
+
+(defn insert-post-admission-registration
+  [oid count quota]
+  (jdbc/execute! @embedded-db/conn (str "INSERT INTO exam_date(exam_date, registration_start_date, registration_end_date, post_admission_end_date) VALUES ('" (two-weeks-from-now) "', '2019-08-01', '2019-10-01', '" (two-weeks-from-now) "')"))
+  (let [exam-date-id (:id (select-one (select-exam-date-id (two-weeks-from-now))))
+        office-oid (-> oid (clojure.string/replace #"'" "") (str ".5"))
+        insert-exam (jdbc/execute! @embedded-db/conn (str "INSERT INTO exam_session (organizer_id,
+          language_code,
+          level_code,
+          office_oid,
+          exam_date_id,
+          max_participants,
+          published_at,
+          post_admission_start_date,
+          post_admission_quota,
+          post_admission_active)
+            VALUES (
+              (SELECT id FROM organizer where oid = " oid "),'fin', 'PERUS', '" office-oid "', " exam-date-id ", " count ", null, '" (two-weeks-ago) "', " quota ", true)"))
+        exam-session-id  (:id (select-one (str "SELECT id FROM exam_session where exam_date_id = " exam-date-id ";")))
+        user-id (:id (select-one (str "SELECT id from participant WHERE external_user_id = 'thirdtest@user.com';")))
+        insert-registration (jdbc/execute! @embedded-db/conn (str "INSERT INTO registration(person_oid, state, exam_session_id, participant_id, form) values ('5.4.3.2.3','COMPLETED', " exam-session-id ", " user-id ",'" (j/write-value-as-string post-admission-registration-form) "')"))]
+    (doall insert-exam)
+    (doall insert-registration)))
 
 (defn login-with-login-link [session]
   (-> session

--- a/test/yki/handler/base_test.clj
+++ b/test/yki/handler/base_test.clj
@@ -357,7 +357,7 @@
   (jdbc/execute! @embedded-db/conn (str "INSERT INTO exam_date(exam_date, registration_start_date, registration_end_date, post_admission_end_date) VALUES ('" (two-weeks-from-now) "', '2019-08-01', '2019-10-01', '" (two-weeks-from-now) "')"))
   (let [exam-date-id (:id (select-one (select-exam-date-id (two-weeks-from-now))))
         office-oid (-> oid (clojure.string/replace #"'" "") (str ".5"))
-        insert-exam (select (str "INSERT INTO exam_session (organizer_id,
+        insert-exam (jdbc/execute! @embedded-db/conn (str "INSERT INTO exam_session (organizer_id,
           language_code,
           level_code,
           office_oid,
@@ -371,7 +371,7 @@
               (SELECT id FROM organizer where oid = " oid "),'fin', 'PERUS', '" office-oid "', " exam-date-id ", " count ", null, '" (two-weeks-ago) "', " quota ", true)"))
         exam-session-id  (:id (select-one (str "SELECT id FROM exam_session where exam_date_id = " exam-date-id ";")))
         user-id (:id (select-one (str "SELECT id from participant WHERE external_user_id = 'thirdtest@user.com';")))
-        insert-registration (select (str "INSERT INTO registration(person_oid, state, exam_session_id, participant_id, form) values ('5.4.3.2.3','COMPLETED', " exam-session-id ", " user-id ",'" (j/write-value-as-string post-admission-registration-form) "')"))]
+        insert-registration (jdbc/execute! @embedded-db/conn (str "INSERT INTO registration(person_oid, state, exam_session_id, participant_id, form) values ('5.4.3.2.3','COMPLETED', " exam-session-id ", " user-id ",'" (j/write-value-as-string post-admission-registration-form) "')"))]
     (doall insert-exam)
     (doall insert-registration)))
 

--- a/test/yki/handler/base_test.clj
+++ b/test/yki/handler/base_test.clj
@@ -190,14 +190,13 @@
   (jdbc/execute! @embedded-db/conn "INSERT INTO exam_date(exam_date, registration_start_date, registration_end_date) VALUES ('2039-05-02', '2039-01-01', '2039-03-01')"))
 
 (defn insert-exam-history-dates [exam-date reg-start reg-end]
-  (println "INSERT EXAM HISTORY DATES: " exam-date reg-start reg-end)
   (jdbc/execute! @embedded-db/conn (str "INSERT INTO exam_date(exam_date, registration_start_date, registration_end_date) VALUES ('" exam-date "', '" reg-start "', '" reg-end "')")))
 
 (def select-participant "(SELECT id from participant WHERE external_user_id = 'test@user.com')")
 
 (def select-exam-session "(SELECT id from exam_session WHERE max_participants = 5)")
 
-(defn select-exam-date-by-date [exam-date]
+(defn select-exam-date-id [exam-date]
   (str "(SELECT id from exam_date WHERE exam_date='" exam-date "')"))
 
 (defn insert-exam-session

--- a/test/yki/handler/exam_session_test.clj
+++ b/test/yki/handler/exam_session_test.clj
@@ -159,7 +159,7 @@
       (is (= (get-exam-date response-body "2039-12-01") "2039-12-01"))
       (is (= (get-exam-date response-body "2039-10-01") nil))))
 
-  (testing "exam session history endpoint with 'days' parameter should return limited sessions history from past days"
+  (testing "exam session history endpoint with 'days' parameter should return limited sessions from past days"
     (let [request (mock/request :get (str routing/organizer-api-root "/1.2.3.4/exam-session/history?from=2040-06-01T00:00:00Z&days=100"))
           response (base/send-request-with-tx request)
           response-body (base/body-as-json response)]

--- a/test/yki/handler/exam_session_test.clj
+++ b/test/yki/handler/exam_session_test.clj
@@ -26,6 +26,43 @@
              (base/select-one "SELECT COUNT(1) FROM exam_session")))
       (is (= (:status response) 400)))))
 
+(deftest ^:test-refresh/focus exam-session-history-test
+  (println "------- this is a history test")
+  (base/insert-organizer "'1.2.3.4'")
+  (base/insert-languages "'1.2.3.4'")
+  ;(base/insert-exam-dates)
+
+  (testing "insert history dates"
+    (let [date-id (fn [date] (-> date
+                                 (base/select-exam-date-by-date)
+                                 (base/select-one)
+                                 :id))
+          ;"2018-01-01T00:00:00Z"
+          history-dates [["2040-06-01" "2040-03-01" "2040-05-30"]
+                         ["2040-04-01" "2040-03-01" "2040-03-30"]
+                         ["2039-12-01" "2040-11-01" "2040-11-30"]
+                         ["2039-10-01" "2039-10-01" "2039-10-30"]]
+          insert-dates (fn [dates] (let [[exam-date reg-start reg-end] dates]
+                                     (base/insert-exam-history-dates exam-date reg-start reg-end)
+                                     (->  (date-id exam-date)
+                                          (base/insert-exam-session "'1.2.3.4'" 5))
+                                     (base/insert-exam-session-location-by-date exam-date "fi")))
+          iterate-dates (fn [dates] (for [d dates] (insert-dates d)))]
+      (doall (iterate-dates history-dates))))
+
+  (testing "get exm session history endpoint should exam session history from past six months"
+    (let [request (mock/request :get (str routing/organizer-api-root "/1.2.3.4/exam-session/history?from=2040-04-1"))
+          response (base/send-request-with-tx request)
+          response-body (base/body-as-json response)
+          exam-sessions (get-in response-body ["exam_sessions"])
+          exam-dates (fn [r] (get-in r ["session_date"]) exam-sessions)]
+      (doall (for [r (get-in response-body ["exam_sessions"])] (println "***" (get-in r ["session_date"]) "***")))
+      (println "Exam dates vector: " (map exam-dates exam-sessions))
+      (is (= (get (:headers response) "Content-Type") "application/json; charset=utf-8"))
+      (is (= (:status response) 200))))
+
+  (testing "get exam session hisotry endpoint with 'days' parameter should return limited exam sessions history from past days"))
+
 (deftest exam-session-crud-test
   (base/insert-organizer "'1.2.3.4'")
   (base/insert-languages "'1.2.3.4'")
@@ -88,42 +125,41 @@
             (deactivate-pa [exam-session-id] (-> (mock-request :post (str exam-session-route "/" exam-session-id "/post-admission/activation") base/post-admission-deactivation)))]
 
       (testing "can add post admission to exam session"
-               (let [create-es-response (create-es)
-                     exam-session-id    (get create-es-response "id")
-                     create-pa-response (create-pa exam-session-id)]
-                 (is (= {:post_admission_start_date "2039-03-02" :post_admission_quota 50 :post_admission_active false}
-                        (base/select-one (str "SELECT post_admission_start_date, post_admission_quota, post_admission_active FROM exam_session WHERE id = " exam-session-id))))))
+        (let [create-es-response (create-es)
+              exam-session-id    (get create-es-response "id")
+              create-pa-response (create-pa exam-session-id)]
+          (is (= {:post_admission_start_date "2039-03-02" :post_admission_quota 50 :post_admission_active false}
+                 (base/select-one (str "SELECT post_admission_start_date, post_admission_quota, post_admission_active FROM exam_session WHERE id = " exam-session-id))))))
 
       (testing "can update existing post admission if post admission has not been activated"
-               (let [create-es-response (create-es)
-                     exam-session-id    (get create-es-response "id")
-                     create-pa-response (create-pa exam-session-id)
-                     update-pa-response (update-pa exam-session-id)]
-                 (is (= {:post_admission_start_date "2039-02-02" :post_admission_quota 10 :post_admission_active false}
-                        (base/select-one (str "SELECT post_admission_start_date, post_admission_quota, post_admission_active FROM exam_session WHERE id = " exam-session-id))))))
+        (let [create-es-response (create-es)
+              exam-session-id    (get create-es-response "id")
+              create-pa-response (create-pa exam-session-id)
+              update-pa-response (update-pa exam-session-id)]
+          (is (= {:post_admission_start_date "2039-02-02" :post_admission_quota 10 :post_admission_active false}
+                 (base/select-one (str "SELECT post_admission_start_date, post_admission_quota, post_admission_active FROM exam_session WHERE id = " exam-session-id))))))
 
       (testing "can not update existing post admission if post admission has been activated"
-               (let [create-es-response   (create-es)
-                     exam-session-id      (get create-es-response "id")
-                     create-pa-response   (create-pa exam-session-id)
-                     activate-pa-response (activate-pa exam-session-id)
-                     update-pa-response   (update-pa exam-session-id)]
-                 (is (= {"success" true} create-pa-response))
-                 (is (= {:post_admission_active true}
-                        (base/select-one (str "SELECT post_admission_active FROM exam_session WHERE id = " exam-session-id))))
-                 (is (= {"success" false "error" "Exam session not found"} update-pa-response))))
+        (let [create-es-response   (create-es)
+              exam-session-id      (get create-es-response "id")
+              create-pa-response   (create-pa exam-session-id)
+              activate-pa-response (activate-pa exam-session-id)
+              update-pa-response   (update-pa exam-session-id)]
+          (is (= {"success" true} create-pa-response))
+          (is (= {:post_admission_active true}
+                 (base/select-one (str "SELECT post_admission_active FROM exam_session WHERE id = " exam-session-id))))
+          (is (= {"success" false "error" "Exam session not found"} update-pa-response))))
 
       (testing "can update activated post admission details again after it has been deactivated"
-               (let [create-es-response     (create-es)
-                     exam-session-id        (get create-es-response "id")
-                     create-pa-response     (create-pa exam-session-id)
-                     activate-pa-response   (activate-pa exam-session-id)
-                     deactivate-pa-response (deactivate-pa exam-session-id)
-                     update-pa-response     (update-pa exam-session-id)]
-                 (is (= {"success" true} update-pa-response))
-                 (is (= {:post_admission_start_date "2039-02-02" :post_admission_quota 10 :post_admission_active false}
-                        (base/select-one (str "SELECT post_admission_start_date, post_admission_quota, post_admission_active FROM exam_session WHERE id = " exam-session-id))))
-                 )))))
+        (let [create-es-response     (create-es)
+              exam-session-id        (get create-es-response "id")
+              create-pa-response     (create-pa exam-session-id)
+              activate-pa-response   (activate-pa exam-session-id)
+              deactivate-pa-response (deactivate-pa exam-session-id)
+              update-pa-response     (update-pa exam-session-id)]
+          (is (= {"success" true} update-pa-response))
+          (is (= {:post_admission_start_date "2039-02-02" :post_admission_quota 10 :post_admission_active false}
+                 (base/select-one (str "SELECT post_admission_start_date, post_admission_quota, post_admission_active FROM exam_session WHERE id = " exam-session-id)))))))))
 
 (deftest exam-session-update-max-participants-fail-test
   (base/insert-base-data)


### PR DESCRIPTION
* Virkailija endpoint "...exam-session/history" takes from timestamp and number of days as parameters. Returns exam sessions history from of how many days was requested
* Adds post admission registrations to csv generator test
* Adds post admissions to registration sync test