### PR TITLE
Exam date handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ lsp/
 
 # Visual Studio Code metadata
 .vscode
+.clj-kondo/
+.lsp/
 
 # Allow all and any scratch files to exist in project root
 scratch.*

--- a/.gitignore
+++ b/.gitignore
@@ -21,11 +21,15 @@ project.clj
 
 # Language Server Protocol (LSP) logfiles
 lsp/
+.lsp/
 
 # Visual Studio Code metadata
 .vscode
 .clj-kondo/
 .lsp/
+
+# Clojure linter
+.clj-kondo/
 
 # Allow all and any scratch files to exist in project root
 scratch.*

--- a/docs/postman/yki_local.postman_collection.json
+++ b/docs/postman/yki_local.postman_collection.json
@@ -7,6 +7,270 @@
 	},
 	"item": [
 		{
+			"name": "Virkailija: Exam date management",
+			"item": [
+				{
+					"name": "Virkailija: Get exam dates",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8f1df71b-9f47-48d4-8281-aae80feef53c",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{virkailija}}/{{oid}}/exam-date",
+							"host": [
+								"{{virkailija}}"
+							],
+							"path": [
+								"{{oid}}",
+								"exam-date"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Virkailija: Create exam date",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9990c550-9c9a-42de-b94b-a84c2c7e3b2e",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setEnvironmentVariable(\"virkailija_exam_date_id\", jsonData.id);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"exam_date\": \"2021-06-09\",\n\t\"registration_start_date\": \"2021-01-01\",\n\t\"registration_end_date\": \"2021-01-30\",\n    \"post_admission_end_date\": \"2021-02-10\",\n\t\"languages\": [\n\t\t{\n\t\t\t\"language_code\": \"fin\",\n\t\t\t\"level_code\": \"YLIN\" \n\t\t}\n\t]\n}\n\n"
+						},
+						"url": {
+							"raw": "{{virkailija}}/{{oid}}/exam-date",
+							"host": [
+								"{{virkailija}}"
+							],
+							"path": [
+								"{{oid}}",
+								"exam-date"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Virkailija: Add language level",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "ac7dfeab-f63e-4fc1-958f-4e0f88147546",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "\n [\n\t\t{\n\t\t\t\"language_code\": \"eng\",\n\t\t\t\"level_code\": \"PERUS\" \n\t\t}\n\t]\n\n\n"
+						},
+						"url": {
+							"raw": "{{virkailija}}/{{oid}}/exam-date/{{virkailija_exam_date_id}}/languages",
+							"host": [
+								"{{virkailija}}"
+							],
+							"path": [
+								"{{oid}}",
+								"exam-date",
+								"{{virkailija_exam_date_id}}",
+								"languages"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Virkailija: Delete language level",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "f71f520d-1e11-41b0-83b4-6099963a1785",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "\n [\n\t\t{\n\t\t\t\"language_code\": \"eng\",\n\t\t\t\"level_code\": \"YLIN\" \n\t\t}\n\t]\n\n\n"
+						},
+						"url": {
+							"raw": "{{virkailija}}/{{oid}}/exam-date/{{virkailija_exam_date_id}}/languages",
+							"host": [
+								"{{virkailija}}"
+							],
+							"path": [
+								"{{oid}}",
+								"exam-date",
+								"{{virkailija_exam_date_id}}",
+								"languages"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Virkailija: Delete exam date",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d835302e-9e31-4dcc-8347-3458c5590ca2",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{virkailija}}/{{oid}}/exam-date/{{virkailija_exam_date_id}}",
+							"host": [
+								"{{virkailija}}"
+							],
+							"path": [
+								"{{oid}}",
+								"exam-date",
+								"{{virkailija_exam_date_id}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Virkailija: Update post admission conf",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "c06f4aab-13ab-43be-937c-5d0f208194f1",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"post_admission_start_date\": \"2021-04-01T00:00:00Z\",\n  \"post_admission_end_date\": \"2021-04-30T00:00:00Z\",\n  \"post_admission_enabled\": true\n}\n"
+						},
+						"url": {
+							"raw": "{{virkailija}}/{{oid}}/exam-date/{{virkailija_exam_date_id}}/post-admission",
+							"host": [
+								"{{virkailija}}"
+							],
+							"path": [
+								"{{oid}}",
+								"exam-date",
+								"{{virkailija_exam_date_id}}",
+								"post-admission"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
 			"name": "Virkailija: Exam session management",
 			"item": [
 				{
@@ -38,7 +302,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"session_date\": \"2020-12-23\", \n\t\"language_code\": \"eng\",\n\t\"level_code\": \"PERUS\",\n\t\"max_participants\": 50,\n\t\"office_oid\": null,\n\t\"published_at\": \"2020-11-04T00:00:00.000Z\",\n\t\"location\": [\n\t\t{\n\t\t\t\"name\": \"Omenia\",\n\t\t\t\"street_address\": \"Upseerinkatu 11\",\n\t\t\t\"post_office\": \"Espoo\",\n\t\t\t\"zip\": \"00240\",\n\t\t\t\"other_location_info\": \"auditorio A2\",\n\t\t\t\"extra_information\": null,\n\t\t\t\"lang\": \"en\"\n\t\t}\n\t]\n}\n"
+							"raw": "{\n\t\"session_date\": \"2021-01-30\", \n\t\"language_code\": \"eng\",\n\t\"level_code\": \"PERUS\",\n\t\"max_participants\": 50,\n\t\"office_oid\": null,\n\t\"published_at\": \"2020-11-04T00:00:00.000Z\",\n\t\"location\": [\n\t\t{\n\t\t\t\"name\": \"Omenia\",\n\t\t\t\"street_address\": \"Upseerinkatu 11\",\n\t\t\t\"post_office\": \"Espoo\",\n\t\t\t\"zip\": \"00240\",\n\t\t\t\"other_location_info\": \"auditorio A2\",\n\t\t\t\"extra_information\": null,\n\t\t\t\"lang\": \"en\"\n\t\t}\n\t]\n}\n"
 						},
 						"url": {
 							"raw": "{{virkailija}}/{{oid}}/exam-session",
@@ -148,13 +412,15 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{virkailija}}/{{oid}}/exam-session",
+							"raw": "{{virkailija}}/{{oid}}/exam-session/{{session_id}}/registration",
 							"host": [
 								"{{virkailija}}"
 							],
 							"path": [
 								"{{oid}}",
-								"exam-session"
+								"exam-session",
+								"{{session_id}}",
+								"registration"
 							]
 						}
 					},

--- a/docs/postman/yki_local.postman_environment.json
+++ b/docs/postman/yki_local.postman_environment.json
@@ -14,7 +14,7 @@
 		},
 		{
 			"key": "date_id",
-			"value": "36",
+			"value": "33",
 			"enabled": true
 		},
 		{
@@ -36,9 +36,14 @@
 			"key": "registration_id",
 			"value": "",
 			"enabled": true
+		},
+		{
+			"key": "virkailija_exam_date_id",
+			"value": "",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2020-11-12T08:38:26.444Z",
-	"_postman_exported_using": "Postman/7.22.1"
+	"_postman_exported_at": "2020-12-01T11:43:17.067Z",
+	"_postman_exported_using": "Postman/7.34.0"
 }

--- a/resources/yki/config.edn
+++ b/resources/yki/config.edn
@@ -21,7 +21,7 @@
 
   :yki/api [#ig/ref :yki.handler/status
             #ig/ref :yki.handler/code
-            #ig/ref :yki.handler/exam-date
+            #ig/ref :yki.handler/exam-date-public
             #ig/ref :yki.handler/auth
             #ig/ref :yki.handler/payment
             #ig/ref :yki.handler/login-link
@@ -103,6 +103,8 @@
 
   :yki.handler/status {:db #ig/ref :duct.database/sql}
 
+  :yki.handler/exam-date-public {:db #ig/ref :duct.database/sql}
+
   :yki.handler/exam-date {:db #ig/ref :duct.database/sql}
 
   :yki.handler/registration {:db #ig/ref :duct.database/sql
@@ -142,13 +144,10 @@
                           :file-handler #ig/ref  :yki.handler/file
                           :access-log #ig/ref :yki.middleware.access-log/with-logging
                           :exam-session-handler #ig/ref :yki.handler/exam-session
+                          :exam-date-handler #ig/ref :yki.handler/exam-date
                           :data-sync-q  #ig/ref :yki.job.job-queue/data-sync-q
-                          :auth #ig/ref :yki.middleware.auth/with-authentication}
+                          :auth #ig/ref :yki.middleware.auth/with-authentication}}
 
-  }
-
-  :duct.profile/dev   #duct/include "dev"
-  :duct.profile/local #duct/include "local"
-  :duct.profile/prod  {}
-}
-
+ :duct.profile/dev   #duct/include "dev"
+ :duct.profile/local #duct/include "local"
+ :duct.profile/prod  {}}

--- a/resources/yki/migrations/010-update-exam-date-and-language.0.1.0.up.sql
+++ b/resources/yki/migrations/010-update-exam-date-and-language.0.1.0.up.sql
@@ -1,0 +1,13 @@
+ALTER TABLE exam_date
+DROP CONSTRAINT exam_date_exam_date_registration_start_date_registration_en_key;
+
+ALTER TABLE exam_date
+ADD COLUMN IF NOT EXISTS post_admission_start_date DATE DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS post_admission_enabled BOOLEAN DEFAULT FALSE,
+ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE DEFAULT NULL;
+
+ALTER TABLE exam_date_language
+DROP CONSTRAINT exam_date_language_exam_date_id_language_code_key;
+
+ALTER TABLE exam_date_language ADD COLUMN IF NOT EXISTS level_code TEXT REFERENCES exam_level (code) DEFAULT 'PERUS';
+ALTER TABLE exam_date_language ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE DEFAULT NULL;

--- a/resources/yki/migrations/010-update-exam-date-and-language.0.1.0.up.sql
+++ b/resources/yki/migrations/010-update-exam-date-and-language.0.1.0.up.sql
@@ -1,5 +1,5 @@
 ALTER TABLE exam_date
-DROP CONSTRAINT exam_date_exam_date_registration_start_date_registration_en_key;
+DROP CONSTRAINT IF EXISTS exam_date_exam_date_registration_start_date_registration_en_key;
 
 ALTER TABLE exam_date
 ADD COLUMN IF NOT EXISTS post_admission_start_date DATE DEFAULT NULL,
@@ -7,7 +7,7 @@ ADD COLUMN IF NOT EXISTS post_admission_enabled BOOLEAN DEFAULT FALSE,
 ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE DEFAULT NULL;
 
 ALTER TABLE exam_date_language
-DROP CONSTRAINT exam_date_language_exam_date_id_language_code_key;
+DROP CONSTRAINT IF EXISTS exam_date_language_exam_date_id_language_code_key;
 
 ALTER TABLE exam_date_language ADD COLUMN IF NOT EXISTS level_code TEXT REFERENCES exam_level (code) DEFAULT 'PERUS';
 ALTER TABLE exam_date_language ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE DEFAULT NULL;

--- a/resources/yki/migrations/011-alter-exam-session-post-admission-columns.0.1.0.up.sql
+++ b/resources/yki/migrations/011-alter-exam-session-post-admission-columns.0.1.0.up.sql
@@ -1,0 +1,24 @@
+DO $$
+BEGIN
+  IF EXISTS(SELECT *
+    FROM information_schema.columns
+    WHERE table_name='exam_session' and column_name='post_admission_start_date')
+  THEN
+      ALTER TABLE "public"."exam_session" RENAME COLUMN "post_admission_start_date" TO "post_admission_activated_at";
+  END IF;
+END $$;
+
+-- Is post registration open for exam session?
+CREATE OR REPLACE FUNCTION exam_session_post_registration_open(exam_date_id bigint,
+                                                               at_point_in_time timestamptz DEFAULT now()) RETURNS SETOF boolean AS $$
+BEGIN
+    RETURN QUERY SELECT EXISTS (
+                     SELECT es.id
+                       FROM exam_session es
+                 INNER JOIN exam_date ed ON es.exam_date_id = ed.id
+                      WHERE es.id = exam_session_post_registration_open.exam_date_id
+                        AND es.post_admission_active = TRUE
+                        AND within_dt_range(at_point_in_time, ed.post_admission_start_date, ed.post_admission_end_date)
+                 ) as exists;
+END;
+$$ LANGUAGE plpgsql;

--- a/resources/yki/migrations/011-alter-exam-session-post-admission-columns.0.1.0.up.sql
+++ b/resources/yki/migrations/011-alter-exam-session-post-admission-columns.0.1.0.up.sql
@@ -1,14 +1,6 @@
-DO $$
-BEGIN
-  IF EXISTS(SELECT *
-    FROM information_schema.columns
-    WHERE table_name='exam_session' and column_name='post_admission_start_date')
-  THEN
-      ALTER TABLE "public"."exam_session" RENAME COLUMN "post_admission_start_date" TO "post_admission_activated_at";
-  END IF;
-END $$;
+ALTER TABLE exam_session
+ADD COLUMN IF NOT EXISTS post_admission_activated_at DATE DEFAULT NULL;
 
--- Is post registration open for exam session?
 CREATE OR REPLACE FUNCTION exam_session_post_registration_open(exam_date_id bigint,
                                                                at_point_in_time timestamptz DEFAULT now()) RETURNS SETOF boolean AS $$
 BEGIN

--- a/resources/yki/migrations/012-drop-exam-date-language-constraint.0.1.0.up.sql
+++ b/resources/yki/migrations/012-drop-exam-date-language-constraint.0.1.0.up.sql
@@ -1,0 +1,4 @@
+-- Drops a constraint that does not appear locally but exists in the cloud
+
+ALTER TABLE exam_date_language
+DROP CONSTRAINT IF EXISTS unique_exam_date_id_language_code;

--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -889,6 +889,10 @@ AND exam_session_id IN (SELECT id
                                               FROM exam_session
                                               WHERE id = :exam_session_id));
 
+-- name: delete-from-exam-session-queue-by-session-id!
+DELETE FROM exam_session_queue
+ WHERE id = :exam_session_id;
+
 -- name: update-exam-session-queue-last-notified-at!
 UPDATE exam_session_queue
 SET last_notified_at = current_timestamp

--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -356,7 +356,7 @@ WHERE exam_session_id = :id;
 DELETE FROM exam_session
 WHERE id = (SELECT es.id FROM exam_session es
             INNER JOIN exam_date ed ON ed.id = es.exam_date_id
-            WHERE es.id = :id AND ed.registration_start_date > current_date
+            WHERE es.id = :id AND ed.registration_start_date >= current_date
             AND es.organizer_id IN (SELECT id FROM organizer WHERE oid = :oid));
 
 -- name: insert-participant<!

--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -264,6 +264,9 @@ SELECT
     FROM registration re
     WHERE re.exam_session_id = e.id AND re.state IN ('COMPLETED', 'SUBMITTED', 'STARTED')
 ) AS participants,
+  (SELECT COUNT(1)
+    FROM registration re
+    WHERE re.exam_session_id = e.id AND re.kind = 'POST_ADMISSION' AND re.state in ('COMPLETED', 'SUBMITTED', 'STARTED')) as pa_participants,
   o.oid as organizer_oid,
 (SELECT array_to_json(array_agg(loc))
   FROM (

--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -850,7 +850,7 @@ ed.post_admission_enabled,
   FROM exam_session
   WHERE exam_date_id = ed.id) AS exam_session_count
 FROM exam_date ed
-WHERE (ed.registration_end_date >= current_date OR ed.post_admission_end_date >= current_date) AND deleted_at IS NULL
+WHERE ed.exam_date >= current_date AND deleted_at IS NULL
 ORDER BY ed.exam_date ASC;
 
 

--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -709,7 +709,7 @@ WHERE ((ed.registration_end_date + interval '1 day') >= current_date
   OR ((ed.registration_end_date + :duration::interval) >= current_date
       AND pss.failed_at IS NOT NULL
       AND (pss.success_at IS NULL OR pss.failed_at > pss.success_at)))
-AND (ed.registration_start_date <= current_date OR es.post_admission_activated_at <= current_date)
+AND (ed.registration_start_date <= current_date OR ed.post_admission_start_date <= current_date)
 AND (SELECT COUNT(1)
      FROM registration re
      WHERE re.exam_session_id = es.id AND re.state = 'COMPLETED') > 0;

--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -850,7 +850,7 @@ ed.post_admission_enabled,
   FROM exam_session
   WHERE exam_date_id = ed.id) AS exam_session_count
 FROM exam_date ed
-WHERE ed.registration_end_date >= current_date AND deleted_at IS NULL
+WHERE (ed.registration_end_date >= current_date OR ed.post_admission_end_date >= current_date) AND deleted_at IS NULL
 ORDER BY ed.exam_date ASC;
 
 
@@ -1061,12 +1061,12 @@ UPDATE exam_session
    SET post_admission_activated_at = now(),
        post_admission_quota = :post_admission_quota,
        post_admission_active = TRUE
-   WHERE post_admission_active = FALSE AND id = :exam_session_id;
+   WHERE id = :exam_session_id;
 
 -- name: deactivate-exam-session-post-admission!
 UPDATE exam_session
    SET post_admission_active = FALSE
-   WHERE post_admission_active = TRUE AND id = :exam_session_id;
+   WHERE id = :exam_session_id;
 
 --name: update-post-admission-end-date!
 UPDATE exam_date

--- a/resources/yki/templates/prequeue_notification.html
+++ b/resources/yki/templates/prequeue_notification.html
@@ -1,0 +1,39 @@
+{% extends "yki/templates/base.html" %} {% block content %}
+<tr>
+  <td style="padding-left: 20px; padding-top: 20px;">
+    {% i18n email.examSession.prequeue.content.line1 %}:
+  </td>
+</tr>
+<tr>
+  <td style="padding-left: 20px; padding-top: 20px;">
+    {{ language }} {{ level|lower }}
+  </td>
+</tr>
+<tr>
+  <td style="padding-left: 20px;">
+    {{exam_date|date-format-with-dots}}
+  </td>
+</tr>
+<tr>
+  <td style="padding-left: 20px;">
+    {{name}}, {{street_address}}, {{zip}} {{post_office}}
+  </td>
+</tr>
+<tr>
+  <td style="padding-left: 20px; padding-top: 20px;">
+    {% i18n email.examSession.queue.content.line2 %}
+  </td>
+</tr>
+<tr>
+  <td style="padding-left: 20px; padding-top: 20px;">
+    <a style="color: #0093C4;" href="{{exam-session-url}}" target="_blank"
+      >{% i18n common.registration %}</a
+    >
+  </td>
+</tr>
+<tr>
+  <td style="padding-left: 20px; padding-top: 20px;">
+    {% i18n email.payment.content.line5 %}
+  </td>
+</tr>
+{% endblock %}

--- a/src/yki/boundary/exam_date_db.clj
+++ b/src/yki/boundary/exam_date_db.clj
@@ -36,6 +36,7 @@
   (get-exam-date-languages [db id])
   (delete-exam-date! [db id])
   (delete-exam-date-languages! [db id languages])
+  (create-and-delete-exam-date-languages! [db id new-languages removed-languages])
   (update-post-admission-details! [db id post-admission])
   (toggle-post-admission! [db id enabled]))
 
@@ -52,12 +53,6 @@
           (doseq [lang (:languages exam-date)]
             (q/insert-exam-date-language! tx (assoc lang :exam_date_id exam-date-id)))
           exam-date-id))))
-  (create-exam-date-languages!
-    [{:keys [spec]} exam-date-id languages]
-    (jdbc/with-db-transaction [tx spec]
-      (doseq [lang languages]
-        (q/insert-exam-date-language! tx (assoc lang :exam_date_id exam-date-id)))
-      true))
   (get-exam-date-by-id [{:keys [spec]} id]
     (first (q/select-exam-date-by-id spec {:id id})))
   (get-exam-dates [{:keys [spec]}]
@@ -95,6 +90,23 @@
     (jdbc/with-db-transaction [tx spec]
       (doseq [lang languages]
         (q/delete-exam-date-language! tx {:exam_date_id id
+                                          :level_code (:level_code lang)
+                                          :language_code (:language_code lang)}))
+      true))
+  (create-exam-date-languages!
+    [{:keys [spec]} exam-date-id languages]
+    (jdbc/with-db-transaction [tx spec]
+      (doseq [lang languages]
+        (q/insert-exam-date-language! tx (assoc lang :exam_date_id exam-date-id)))
+      true))
+
+  (create-and-delete-exam-date-languages!
+    [{:keys [spec]} exam-date-id added-languages removed-languages]
+    (jdbc/with-db-transaction [tx spec]
+      (doseq [lang added-languages]
+        (q/insert-exam-date-language! tx (assoc lang :exam_date_id exam-date-id)))
+      (doseq [lang removed-languages]
+        (q/delete-exam-date-language! tx {:exam_date_id exam-date-id
                                           :level_code (:level_code lang)
                                           :language_code (:language_code lang)}))
       true)))

--- a/src/yki/boundary/exam_date_db.clj
+++ b/src/yki/boundary/exam_date_db.clj
@@ -37,8 +37,7 @@
   (delete-exam-date! [db id])
   (delete-exam-date-languages! [db id languages])
   (update-post-admission-details! [db id post-admission])
-  (delete-post-admission-end-date! [db exam-date-id])
-  (update-post-admission-end-date! [db exam-date-id new-end-date]))
+  (toggle-post-admission! [db id enabled]))
 
 (extend-protocol ExamDate
   duct.database.sql.Boundary
@@ -82,6 +81,11 @@
                                                       :post_admission_start_date (string->date (:post_admission_start_date post-admission))
                                                       :post_admission_end_date (string->date (:post_admission_end_date post-admission))
                                                       :post_admission_enabled (:post_admission_enabled post-admission)})))
+  (toggle-post-admission!
+    [{:keys [spec]} id enabled]
+    (jdbc/with-db-transaction [tx spec]
+      (q/update-exam-date-post-admission-status! tx {:id id
+                                                     :post_admission_enabled enabled})))
   (delete-exam-date! [{:keys [spec]} id]
     (jdbc/with-db-transaction [tx spec]
       (q/delete-exam-date! tx {:id id})
@@ -93,10 +97,4 @@
         (q/delete-exam-date-language! tx {:exam_date_id id
                                           :level_code (:level_code lang)
                                           :language_code (:language_code lang)}))
-      true))
-  (delete-post-admission-end-date! [{:keys [spec]} exam-date-id]
-    (jdbc/with-db-transaction [tx spec]
-      (q/delete-post-admission-end-date! tx {:exam_date_id exam-date-id})))
-  (update-post-admission-end-date! [{:keys [spec]} exam-date-id new-end-date]
-    (jdbc/with-db-transaction [tx spec]
-      (q/update-post-admission-end-date! tx {:exam_date_id exam-date-id :post_admission_end_date (f/parse new-end-date)}))))
+      true)))

--- a/src/yki/boundary/exam_date_db.clj
+++ b/src/yki/boundary/exam_date_db.clj
@@ -3,19 +3,97 @@
    [jeesql.core :refer [require-sql]]
    [clojure.java.jdbc :as jdbc]
    [clj-time.format :as f]
+   [clojure.tools.logging :as log]
    [duct.database.sql]))
 
 (require-sql ["yki/queries.sql" :as q])
 
+(defn- convert-dates [exam-date]
+  (reduce #(update-in %1 [%2] f/parse) exam-date [:exam_date
+                                                  :registration_start_date
+                                                  :registration_end_date]))
+(defn- string->date [date]
+  (if (some? date)
+    (f/parse date)))
+
+(defn rollback-on-exception [tx f]
+  (try
+    (f)
+    (catch Exception e
+      (.rollback (:connection tx))
+      (log/error e "Execution failed. Rolling back transaction.")
+      (throw e))))
+
 (defprotocol ExamDate
+  (create-exam-date! [db exam-date])
+  (create-exam-date-languages! [db exam-date-id languages])
   (get-exam-dates [db])
+  (get-organizer-exam-dates [db])
+  (get-exam-date-by-id [db id])
+  (get-exam-date-session-count [db id])
+  (get-exam-dates-by-date [db exam-date])
+  (get-exam-date-language [db id language])
+  (get-exam-date-languages [db id])
+  (delete-exam-date! [db id])
+  (delete-exam-date-languages! [db id languages])
+  (update-post-admission-details! [db id post-admission])
   (delete-post-admission-end-date! [db exam-date-id])
   (update-post-admission-end-date! [db exam-date-id new-end-date]))
 
 (extend-protocol ExamDate
   duct.database.sql.Boundary
+  (create-exam-date!
+    [{:keys [spec]} exam-date]
+    (jdbc/with-db-transaction [tx spec]
+      (rollback-on-exception
+       tx
+       #(let [converted-dates (convert-dates exam-date)
+              result (q/insert-exam-date<! tx converted-dates)
+              exam-date-id (:id result)]
+          (doseq [lang (:languages exam-date)]
+            (q/insert-exam-date-language! tx (assoc lang :exam_date_id exam-date-id)))
+          exam-date-id))))
+  (create-exam-date-languages!
+    [{:keys [spec]} exam-date-id languages]
+    (jdbc/with-db-transaction [tx spec]
+      (doseq [lang languages]
+        (q/insert-exam-date-language! tx (assoc lang :exam_date_id exam-date-id)))
+      true))
+  (get-exam-date-by-id [{:keys [spec]} id]
+    (first (q/select-exam-date-by-id spec {:id id})))
   (get-exam-dates [{:keys [spec]}]
     (q/select-exam-dates spec))
+  (get-organizer-exam-dates [{:keys [spec]}]
+    (q/select-organizer-exam-dates spec))
+  (get-exam-date-session-count [{:keys [spec]} id]
+    (first (q/select-exam-date-session-count spec {:id id})))
+  (get-exam-dates-by-date [{:keys [spec]} exam-date]
+    (q/select-exam-dates-by-date spec {:exam_date exam-date}))
+  (get-exam-date-language [{:keys [spec]} id language]
+    (q/select-exam-date-language spec {:exam_date_id id
+                                       :level_code (:level_code language)
+                                       :language_code (:language_code language)}))
+  (get-exam-date-languages [{:keys [spec]} id]
+    (q/select-exam-date-languages spec {:exam_date_id id}))
+  (update-post-admission-details!
+    [{:keys [spec]} id post-admission]
+    (jdbc/with-db-transaction [tx spec]
+      (q/update-exam-date-post-admission-details! tx {:id id
+                                                      :post_admission_start_date (string->date (:post_admission_start_date post-admission))
+                                                      :post_admission_end_date (string->date (:post_admission_end_date post-admission))
+                                                      :post_admission_enabled (:post_admission_enabled post-admission)})))
+  (delete-exam-date! [{:keys [spec]} id]
+    (jdbc/with-db-transaction [tx spec]
+      (q/delete-exam-date! tx {:id id})
+      (q/delete-exam-date-languages! tx {:exam_date_id id})))
+
+  (delete-exam-date-languages! [{:keys [spec]} id languages]
+    (jdbc/with-db-transaction [tx spec]
+      (doseq [lang languages]
+        (q/delete-exam-date-language! tx {:exam_date_id id
+                                          :level_code (:level_code lang)
+                                          :language_code (:language_code lang)}))
+      true))
   (delete-post-admission-end-date! [{:keys [spec]} exam-date-id]
     (jdbc/with-db-transaction [tx spec]
       (q/delete-post-admission-end-date! tx {:exam_date_id exam-date-id})))

--- a/src/yki/boundary/exam_session_db.clj
+++ b/src/yki/boundary/exam_session_db.clj
@@ -54,8 +54,8 @@
   (add-to-exam-session-queue! [db email lang exam-session-id])
   (update-exam-session-queue-last-notified-at! [db email exam-session-id])
   (remove-from-exam-session-queue! [db email exam-session-id])
-  (update-post-admission-details! [db id post-admission])
-  (set-post-admission-active! [db activation]))
+  (set-post-admission-active! [db id quota])
+  (set-post-admission-deactive! [db id]))
 
 (extend-protocol ExamSessions
   duct.database.sql.Boundary
@@ -154,18 +154,14 @@
       (q/delete-from-exam-session-queue! tx {:exam_session_id exam-session-id
                                              :email email})))
 
-  (update-post-admission-details!
-    [{:keys [spec]} id post-admission]
-    (jdbc/with-db-transaction [tx spec]
-      (let [current-post-admission (first (q/fetch-post-admission-details tx {:exam_session_id id}))]
-        (when (and (false? (:post_admission_active current-post-admission))
-                   (> (:post_admission_quota post-admission) 0))
-          (q/update-post-admission-details! tx {:exam_session_id id
-                                                :post_admission_start_date (string->date (:post_admission_start_date post-admission))
-                                                :post_admission_quota (:post_admission_quota post-admission)})))))
   (set-post-admission-active!
-    [{:keys [spec]} activation]
-    (log/debug (str "Changing post admission active state to " (:post_admission_active activation) " for exam session " (:exam_session_id activation)))
-    (int->boolean (jdbc/with-db-transaction [tx spec]
-                    (q/activate-post-admission! tx activation)))))
+    [{:keys [spec]} id quota]
+    (jdbc/with-db-transaction [tx spec]
+      (q/activate-exam-session-post-admission! tx {:exam_session_id id
+                                                   :post_admission_quota quota})))
+
+  (set-post-admission-deactive!
+    [{:keys [spec]} id]
+    (jdbc/with-db-transaction [tx spec]
+      (q/deactivate-exam-session-post-admission! tx {:exam_session_id id}))))
 

--- a/src/yki/handler/exam_date.clj
+++ b/src/yki/handler/exam_date.clj
@@ -1,30 +1,146 @@
 (ns yki.handler.exam-date
-  (:require [compojure.api.sweet :refer [context GET DELETE POST]]
+  (:require [compojure.api.sweet :refer [context GET DELETE POST PUT]]
             [yki.boundary.exam-date-db :as exam-date-db]
-            [ring.util.http-response :refer [ok not-found]]
+            [ring.util.http-response :refer [ok not-found conflict internal-server-error]]
+            [yki.util.audit-log :as audit-log]
+            [clojure.tools.logging :as log]
             [yki.spec :as ys]
             [yki.handler.routing :as routing]
-            [integrant.core :as ig]))
+            [clj-time.coerce :as c]
+            [clj-time.core :as t]
+            [integrant.core :as ig]
+            [clojure.string :as str]))
+
+(defn is-first-date-before-second [current-date post-date]
+  (if (nil? post-date) false (let [to-date (fn [d] (c/from-long d))]
+                               (t/before? (to-date current-date) (to-date post-date)))))
 
 (defmethod ig/init-key :yki.handler/exam-date [_ {:keys [db]}]
-  (context routing/exam-date-api-root []
-    :coercion :spec
-    (GET "/" []
-      :return ::ys/exam-date-response
-      (ok {:dates (exam-date-db/get-exam-dates db)}))
+  (fn [oid]
+    (context "/" []
+      (GET "/" []
+        :return ::ys/exam-date-response
+        (ok {:dates (exam-date-db/get-organizer-exam-dates db)}))
+      (POST "/" request
+        :body [exam-date ::ys/exam-date-type]
+        :return ::ys/id-response
+        (let [{exam :exam_date
+               reg-start :registration_start_date
+               reg-end :registration_end_date} exam-date
+              existing-exam-dates (exam-date-db/get-exam-dates-by-date db (c/from-long exam))]
+          (cond
+            (= false (empty? existing-exam-dates)) (conflict {:success false :error "Exam date already exists"})
+            (is-first-date-before-second reg-end reg-start) (conflict {:success false :error "Registeration start date has to be before it's end date"})
+            (is-first-date-before-second exam reg-end) (conflict {:success false :error "Registeration end date needs to be before exam date"})
+            :else
+            (let [exam-date-id (exam-date-db/create-exam-date! db exam-date)]
+              (if exam-date-id
+                (do
+                  (audit-log/log {:request request
+                                  :target-kv {:k audit-log/exam-date
+                                              :v exam-date-id}
+                                  :change {:type audit-log/create-op
+                                           :new exam-date}})
+                  (ok {:id exam-date-id}))
+                (internal-server-error
+                 {:success false :error "Could not create an exam date"}))))))
+
       (context "/:id" []
-        (POST "/post-admission-end-date" []
-          :body [end-date ::ys/post-admission-end-date-update]
+        (GET "/" []
+          :path-params [id :- ::ys/id]
+          :return ::ys/single-exam-date-response
+          (if-let [exam-date (exam-date-db/get-exam-date-by-id db id)]
+            (ok {:date exam-date})
+            (not-found {:success false
+                        :error "Exam date not found"})))
+
+        (DELETE "/" request
           :path-params [id :- ::ys/id]
           :return ::ys/response
-          (if (nil? (:post_admission_end_date end-date))
-              (not-found {:success false :error "End date can not be null"})
-              (if (exam-date-db/update-post-admission-end-date! db id (:post_admission_end_date end-date))
-                  (ok {:success true})
-                  (not-found {:success false :error "Exam date not found"}))))
-        (DELETE "/post-admission-end-date" []
+          (let [exam-date (exam-date-db/get-exam-date-by-id db id)
+                session-count (:count (exam-date-db/get-exam-date-session-count db id))]
+            (cond
+              (= exam-date nil) (not-found {:success false :error "Exam date not found"})
+              (> session-count 0) (conflict {:success false :error "Cannot delete exam date with assigned exam sessions"})
+              :else (if (exam-date-db/delete-exam-date! db id)
+                      (do
+                        (audit-log/log {:request request
+                                        :target-kv {:k audit-log/exam-date
+                                                    :v id}
+                                        :change {:type audit-log/delete-op}})
+                        (ok {:success true}))
+                      (internal-server-error {:success false
+                                              :error "Could not delete the exam date"})))))
+
+        (POST "/post-admission" request
           :path-params [id :- ::ys/id]
+          :body [post-admission ::ys/exam-date-post-admission-update]
           :return ::ys/response
-          (if (exam-date-db/delete-post-admission-end-date! db id)
-              (ok {:success true})
-              (not-found {:success false :error "Exam date not found"}))))))
+          (let [{post-start :post_admission_start_date post-end :post_admission_end_date} post-admission
+                current (exam-date-db/get-exam-date-by-id db id)
+                post-admission-date-errors (remove nil?
+                                                   (vector
+                                                    (when (is-first-date-before-second post-end post-start)
+                                                      {:success false :error "Post admission start date has to be before it's end date"})
+                                                    (when (is-first-date-before-second post-start (:registration_end_date current))
+                                                      {:success false :error "Post admission start date has to be after registration has ended"})
+                                                    (when (is-first-date-before-second (:exam_date current) post-end)
+                                                      {:success false :error "Post admission end date has to be before exam date"})))]
+            (cond
+              (= current nil) (not-found
+                               {:success false :error "Exam date not found"})
+              (not-empty post-admission-date-errors) (conflict (first post-admission-date-errors))
+              :else (if (exam-date-db/update-post-admission-details! db id post-admission)
+                      (ok {:success true})
+                      (internal-server-error {:success false :error "Could not delete the exam date"})))))
+
+        (POST "/languages" request
+          :path-params [id :- ::ys/id]
+          :body [languages ::ys/languages]
+          :return ::ys/response
+          (let [exam-date (exam-date-db/get-exam-date-by-id db id)
+                exam-date-languages (:languages exam-date)
+                existing-row (fn [old-lang new-lang] (when (and
+                                                            (= (:language_code old-lang) (:language_code new-lang))
+                                                            (= (:level_code old-lang) (:level_code new-lang))) new-lang))
+                map-language-rows (fn [lang]  (remove nil? (map (fn [row] (existing-row lang row)) languages)))
+                get-existing-rows (->> exam-date-languages
+                                       (map map-language-rows)
+                                       flatten)
+                language-error-message (when (= false (empty? get-existing-rows))
+                                         (str "Following language levels exist for this exam date: " (str/join get-existing-rows)))]
+            (cond
+              (= exam-date nil) (not-found {:success false :error "Exam date not found"})
+              (= false (nil? language-error-message)) (conflict {:success false :error language-error-message})
+              :else
+              (if (exam-date-db/create-exam-date-languages! db id languages)
+                (do
+                  (audit-log/log {:request request
+                                  :target-kv {:k audit-log/exam-date
+                                              :v id}
+                                  :change {:type audit-log/update-op
+                                           :old exam-date
+                                           :new (assoc exam-date :languages (concat (:languages exam-date) languages))}})
+                  (ok {:success true}))
+                (internal-server-error {:success false :error "Could not create exam date languages"})))))
+
+        (DELETE "/languages" request
+          :path-params [id :- ::ys/id]
+          :body [languages ::ys/languages]
+          :return ::ys/response
+          (let [exam-date (exam-date-db/get-exam-date-by-id db id)
+                session-count (:count (exam-date-db/get-exam-date-session-count db id))]
+            (cond
+              (= exam-date nil) (not-found {:success false :error "Exam date not found"})
+              (> session-count 0) (conflict {:success false :error "Cannot delete languages from exam date with assigned exam sessions"})
+              :else
+              (if (exam-date-db/delete-exam-date-languages! db id languages)
+                (do
+                  (audit-log/log {:request request
+                                  :target-kv {:k audit-log/exam-date
+                                              :v id}
+                                  :change {:type audit-log/update-op
+                                           :old exam-date
+                                           :new (assoc exam-date :languages (:languages (exam-date-db/get-exam-date-by-id db id)))}})
+                  (ok {:success true}))
+                (internal-server-error {:success false :error "Could not delete exam date languages"})))))))))

--- a/src/yki/handler/exam_date.clj
+++ b/src/yki/handler/exam_date.clj
@@ -16,18 +16,21 @@
                                (t/before? (to-date current-date) (to-date post-date)))))
 
 (defn toggle-post-admission [db id enabled]
-  (let [current (exam-date-db/get-exam-date-by-id db id)
-        is-configured? (and
-                        (some? (:post_admission_start_date current))
-                        (some? (:post_admission_end_date current)))]
+  (let [current                (exam-date-db/get-exam-date-by-id db id)
+        is-configured?         (and
+                                (some? (:post_admission_start_date current))
+                                (some? (:post_admission_end_date current)))]
     (cond
-      (= current nil) (not-found
-                       {:success false :error "Exam date not found"})
-      (= false is-configured?) (conflict
-                                {:success false :error "Post admission start and end dates are not configured"})
-      :else (if (exam-date-db/toggle-post-admission! db id enabled)
-              (ok {:success true})
-              (internal-server-error {:success false :error "Could not enable post admission for the exam date"})))))
+      (= current nil)          (do (log/error "Could not find exam date with id " id)
+                                   (not-found
+                                    {:success false :error "Exam date not found"}))
+      (= false is-configured?) (do (log/error "Exam date " id " post admission start and end dates are not configured")
+                                   (conflict
+                                    {:success false :error "Post admission start and end dates are not configured"}))
+      :else                    (if (exam-date-db/toggle-post-admission! db id enabled)
+                                 (ok {:success true})
+                                 (do (log/error "Error occured when trying to enable post admission for exam date " id)
+                                     (internal-server-error {:success false :error "Could not enable post admission for the exam date"}))))))
 
 (defmethod ig/init-key :yki.handler/exam-date [_ {:keys [db]}]
   (fn [oid]
@@ -38,14 +41,18 @@
       (POST "/" request
         :body [exam-date ::ys/exam-date-type]
         :return ::ys/id-response
+        (log/info "Creating a new exam date")
         (let [{exam :exam_date
                reg-start :registration_start_date
                reg-end :registration_end_date} exam-date
               existing-exam-dates (exam-date-db/get-exam-dates-by-date db (c/from-long exam))]
           (cond
-            (= false (empty? existing-exam-dates)) (conflict {:success false :error "Exam date already exists"})
-            (is-first-date-before-second reg-end reg-start) (conflict {:success false :error "Registeration start date has to be before it's end date"})
-            (is-first-date-before-second exam reg-end) (conflict {:success false :error "Registeration end date needs to be before exam date"})
+            (= false (empty? existing-exam-dates))          (do (log/error "Exam date " exam " already exists")
+                                                                (conflict {:success false :error "Exam date already exists"}))
+            (is-first-date-before-second reg-end reg-start) (do (log/error "Registeration start date " reg-start " has to be before it's end date " reg-end)
+                                                                (conflict {:success false :error "Registeration start date has to be before it's end date"}))
+            (is-first-date-before-second exam reg-end)      (do (log/error "Registeration end date " reg-end " needs to be before exam date " exam)
+                                                                (conflict {:success false :error "Registeration end date needs to be before exam date"}))
             :else
             (let [exam-date-id (exam-date-db/create-exam-date! db exam-date)]
               (if exam-date-id
@@ -56,8 +63,9 @@
                                   :change {:type audit-log/create-op
                                            :new exam-date}})
                   (ok {:id exam-date-id}))
-                (internal-server-error
-                 {:success false :error "Could not create an exam date"}))))))
+                (do (log/error "Error occured when attempting to create a new exam date " exam)
+                    (internal-server-error
+                     {:success false :error "Could not create an exam date"})))))))
 
       (context "/:id" []
         (GET "/" []
@@ -65,17 +73,21 @@
           :return ::ys/single-exam-date-response
           (if-let [exam-date (exam-date-db/get-exam-date-by-id db id)]
             (ok {:date exam-date})
-            (not-found {:success false
-                        :error "Exam date not found"})))
+            (do (log/error "Could not find an exam date with id " id)
+                (not-found {:success false
+                            :error "Exam date not found"}))))
 
         (DELETE "/" request
           :path-params [id :- ::ys/id]
           :return ::ys/response
+          (log/info "Deleting exam date " id)
           (let [exam-date (exam-date-db/get-exam-date-by-id db id)
                 session-count (:count (exam-date-db/get-exam-date-session-count db id))]
             (cond
-              (= exam-date nil) (not-found {:success false :error "Exam date not found"})
-              (> session-count 0) (conflict {:success false :error "Cannot delete exam date with assigned exam sessions"})
+              (= exam-date nil)   (do (log/error "Could not find an exam date " id " to delete")
+                                      (not-found {:success false :error "Exam date not found"}))
+              (> session-count 0) (do (log/error "Cannot delete an exam date " id " because it has exam sessions assigned to it")
+                                      (conflict {:success false :error "Cannot delete exam date with assigned exam sessions"}))
               :else (if (exam-date-db/delete-exam-date! db id)
                       (do
                         (audit-log/log {:request request
@@ -83,8 +95,9 @@
                                                     :v id}
                                         :change {:type audit-log/delete-op}})
                         (ok {:success true}))
-                      (internal-server-error {:success false
-                                              :error "Could not delete the exam date"})))))
+                      (do (log/error "Error occured when attempting to delete exam date " id)
+                          (internal-server-error {:success false
+                                                  :error "Could not delete the exam date"}))))))
 
         (POST "/languages" request
           :path-params [id :- ::ys/id]
@@ -99,7 +112,8 @@
             (when (not-empty removable-languages) (log/info "Removing languages from exam date " id ": " removable-languages))
 
             (cond
-              (= exam-date nil) (not-found {:success false :error "Exam date not found"})
+              (= exam-date nil) (do (log/error "Could not find an exam date " id " to modify")
+                                    (not-found {:success false :error "Exam date not found"}))
               :else
               (if (exam-date-db/create-and-delete-exam-date-languages! db id new-languages removable-languages)
                 (do
@@ -110,28 +124,8 @@
                                            :old exam-date
                                            :new (assoc exam-date :languages (concat (:languages exam-date) languages))}})
                   (ok {:success true}))
-                (internal-server-error {:success false :error "Could not create exam date languages"})))))
-
-        (DELETE "/languages" request
-          :path-params [id :- ::ys/id]
-          :body [languages ::ys/languages]
-          :return ::ys/response
-          (let [exam-date (exam-date-db/get-exam-date-by-id db id)
-                session-count (:count (exam-date-db/get-exam-date-session-count db id))]
-            (cond
-              (= exam-date nil) (not-found {:success false :error "Exam date not found"})
-              (> session-count 0) (conflict {:success false :error "Cannot delete languages from exam date with assigned exam sessions"})
-              :else
-              (if (exam-date-db/delete-exam-date-languages! db id languages)
-                (do
-                  (audit-log/log {:request request
-                                  :target-kv {:k audit-log/exam-date
-                                              :v id}
-                                  :change {:type audit-log/update-op
-                                           :old exam-date
-                                           :new (assoc exam-date :languages (:languages (exam-date-db/get-exam-date-by-id db id)))}})
-                  (ok {:success true}))
-                (internal-server-error {:success false :error "Could not delete exam date languages"})))))
+                (do (log/error "Error occured when modifying languages in exam date " id)
+                    (internal-server-error {:success false :error "Could not create exam date languages"}))))))
 
         (context "/post-admission" []
           (POST "/" request
@@ -149,12 +143,13 @@
                                                       (when (is-first-date-before-second (:exam_date current) post-end)
                                                         {:success false :error "Post admission end date has to be before exam date"})))]
               (cond
-                (= current nil) (not-found
-                                 {:success false :error "Exam date not found"})
-                (not-empty post-admission-date-errors) (conflict (first post-admission-date-errors))
+                (= current nil)                        (not-found {:success false :error "Exam date not found"})
+                (not-empty post-admission-date-errors) (do (log/error "Conflict in post admission handling for exam date " id ": " (first post-admission-date-errors))
+                                                           (conflict (first post-admission-date-errors)))
                 :else (if (exam-date-db/update-post-admission-details! db id post-admission)
                         (ok {:success true})
-                        (internal-server-error {:success false :error "Could not delete the exam date"})))))
+                        (do (log/error "Error occured when attempting to configure post admission for exam date " id)
+                            (internal-server-error {:success false :error "Could not configure post admission"}))))))
 
           (POST "/enable" request
             :path-params [id :- ::ys/id]

--- a/src/yki/handler/exam_date_public.clj
+++ b/src/yki/handler/exam_date_public.clj
@@ -1,0 +1,30 @@
+(ns yki.handler.exam-date-public
+  (:require [compojure.api.sweet :refer [context GET DELETE POST]]
+            [yki.boundary.exam-date-db :as exam-date-db]
+            [ring.util.http-response :refer [ok not-found]]
+            [yki.spec :as ys]
+            [yki.handler.routing :as routing]
+            [integrant.core :as ig]))
+
+(defmethod ig/init-key :yki.handler/exam-date-public [_ {:keys [db]}]
+  (context routing/exam-date-api-root []
+    :coercion :spec
+    (GET "/" []
+      :return ::ys/exam-date-response
+      (ok {:dates (exam-date-db/get-exam-dates db)}))
+    (context "/:id" []
+      (POST "/post-admission-end-date" []
+        :body [end-date ::ys/post-admission-end-date-update]
+        :path-params [id :- ::ys/id]
+        :return ::ys/response
+        (if (nil? (:post_admission_end_date end-date))
+          (not-found {:success false :error "End date can not be null"})
+          (if (exam-date-db/update-post-admission-end-date! db id (:post_admission_end_date end-date))
+            (ok {:success true})
+            (not-found {:success false :error "Exam date not found"}))))
+      (DELETE "/post-admission-end-date" []
+        :path-params [id :- ::ys/id]
+        :return ::ys/response
+        (if (exam-date-db/delete-post-admission-end-date! db id)
+          (ok {:success true})
+          (not-found {:success false :error "Exam date not found"}))))))

--- a/src/yki/handler/exam_date_public.clj
+++ b/src/yki/handler/exam_date_public.clj
@@ -11,20 +11,4 @@
     :coercion :spec
     (GET "/" []
       :return ::ys/exam-date-response
-      (ok {:dates (exam-date-db/get-exam-dates db)}))
-    (context "/:id" []
-      (POST "/post-admission-end-date" []
-        :body [end-date ::ys/post-admission-end-date-update]
-        :path-params [id :- ::ys/id]
-        :return ::ys/response
-        (if (nil? (:post_admission_end_date end-date))
-          (not-found {:success false :error "End date can not be null"})
-          (if (exam-date-db/update-post-admission-end-date! db id (:post_admission_end_date end-date))
-            (ok {:success true})
-            (not-found {:success false :error "Exam date not found"}))))
-      (DELETE "/post-admission-end-date" []
-        :path-params [id :- ::ys/id]
-        :return ::ys/response
-        (if (exam-date-db/delete-post-admission-end-date! db id)
-          (ok {:success true})
-          (not-found {:success false :error "Exam date not found"}))))))
+      (ok {:dates (exam-date-db/get-exam-dates db)}))))

--- a/src/yki/handler/exam_session.clj
+++ b/src/yki/handler/exam_session.clj
@@ -27,9 +27,15 @@
   (fn [oid]
     (context "/" []
       (GET "/" []
-        :query-params [{from :- ::ys/date nil}]
+        :query-params [{from :- ::ys/date nil} {days :- ::ys/days nil}]
         :return ::ys/exam-sessions-response
-        (response {:exam_sessions (exam-session-db/get-exam-sessions db oid from)}))
+        (let [from-date  (if from (c/from-long from) (t/now))
+              history-date (if days (-> from-date
+                                        (t/minus (t/days days))) from-date)
+              new-from-date (f/unparse (f/formatter "yyyy-MM-dd") history-date)
+              sessions (exam-session-db/get-exam-sessions db oid new-from-date)]
+          (response {:exam_sessions sessions})))
+
       (POST "/" request
         :body [exam-session ::ys/exam-session]
         :return ::ys/id-response
@@ -45,16 +51,6 @@
                             :change {:type audit-log/create-op
                                      :new exam-session}})
             (response {:id exam-session-id}))))
-      (context "/history" []
-        (GET "/" []
-          :query-params [{from :- ::ys/date nil} {days :- ::ys/days nil}]
-          :return ::ys/exam-sessions-response
-          (let [history-date (-> from
-                                 (c/to-long)
-                                 (c/from-long)
-                                 (t/minus (t/days (if days days 180))))
-                string-date (f/unparse (f/formatter "yyyy-MM-dd") history-date)]
-            (response {:exam_sessions (exam-session-db/get-exam-sessions db oid string-date)}))))
 
       (context "/:id" []
         (PUT "/" request
@@ -88,12 +84,15 @@
                 reg-start-date (when exam-session (c/from-long (:registration_start_date exam-session)))]
             (log/info "Deleting exam session: " id)
             (cond
-              (nil? exam-session)               (not-found {:success false
-                                                            :error "Exam session not found"})
-              (> participants 0)                (conflict {:success false
-                                                           :error "Cannot delete exam session with participants"})
-              (t/after? (t/now) reg-start-date) (conflict {:success false
-                                                           :error "Cannot delete exam session after registration has started"})
+              (nil? exam-session) (do (log/error "Could not find exam session " id)
+                                      (not-found {:success false
+                                                  :error "Exam session not found"}))
+              (> participants 0) (do (log/error "Cannot delete exam session with participants " id)
+                                     (conflict {:success false
+                                                :error "Cannot delete exam session with participants"}))
+              (t/after? (t/minus (t/now) (t/days 1)) reg-start-date) (do (log/error "Cannot delete exam session after registration start date " id)
+                                                                         (conflict {:success false
+                                                                                    :error "Cannot delete exam session after registration start date "}))
               :else (if (exam-session-db/delete-exam-session! db id oid (send-to-queue
                                                                          data-sync-q
                                                                          (assoc exam-session :organizer_oid oid)
@@ -104,8 +103,9 @@
                                                     :v id}
                                         :change {:type audit-log/delete-op}})
                         (response {:success true}))
-                      (not-found {:success false
-                                  :error "Exam session not found"})))))
+                      (do (log/error "Error occured when deleting exam session " id)
+                          (not-found {:success false
+                                      :error "Exam session not found"}))))))
 
         (POST routing/post-admission-uri request
           :path-params [id :- ::ys/id]

--- a/src/yki/handler/exam_session_public.clj
+++ b/src/yki/handler/exam_session_public.clj
@@ -17,7 +17,7 @@
   (context routing/exam-session-public-api-root []
     :coercion :spec
     (GET "/" []
-      :query-params [{from :- ::ys/date nil}]
+      :query-params [{from :- ::ys/date-type nil}]
       :return ::ys/exam-sessions-response
       (let [exam-sessions (exam-session-db/get-exam-sessions db nil from)
             with-fee (map #(assoc % :exam_fee (get-exam-fee payment-config %)) exam-sessions)]

--- a/src/yki/handler/login_link.clj
+++ b/src/yki/handler/login_link.clj
@@ -9,6 +9,7 @@
             [yki.util.common :as c]
             [pgqueue.core :as pgq]
             [clj-time.core :as t]
+            [clojure.tools.logging :as log]
             [yki.job.job-queue]
             [ring.util.http-response :refer [ok]]
             [buddy.core.hash :as hash]
@@ -29,6 +30,7 @@
        :body [login-link ::ys/login-link]
        :query-params [lang :- ::ys/language-code]
        :return ::ys/response
+       (log/info "Login link requested for: " login-link)
        (let [participant-id   (:id (registration-db/get-or-create-participant! db {:external_user_id (:email login-link)
                                                                                    :email (:email login-link)}))
              exam-session-id  (:exam_session_id login-link)

--- a/src/yki/handler/organizer.clj
+++ b/src/yki/handler/organizer.clj
@@ -23,8 +23,8 @@
                           :type "DELETE"
                           :created (System/currentTimeMillis)})))
 
-(defmethod ig/init-key :yki.handler/organizer [_ {:keys [db url-helper auth file-handler exam-session-handler data-sync-q access-log]}]
-  {:pre [(some? db) (some? url-helper) (some? auth) (some? file-handler) (some? exam-session-handler) (some? data-sync-q) (some? access-log)]}
+(defmethod ig/init-key :yki.handler/organizer [_ {:keys [db url-helper auth file-handler exam-session-handler exam-date-handler data-sync-q access-log]}]
+  {:pre [(some? db) (some? url-helper) (some? auth) (some? file-handler) (some? exam-session-handler) (some? exam-date-handler) (some? data-sync-q) (some? access-log)]}
   (api
    (context routing/organizer-api-root []
      :middleware [auth access-log]
@@ -35,8 +35,8 @@
        (log/info "creating organizer" organizer)
        (when (organizer-db/create-organizer! db organizer)
          (audit-log/log
-          {:request request,
-           :target-kv {:k audit-log/organizer, :v (:oid organizer)},
+          {:request request
+           :target-kv {:k audit-log/organizer, :v (:oid organizer)}
            :change {:type audit-log/create-op, :new organizer}})
          (response {:success true})))
      (GET "/" {session :session}
@@ -80,4 +80,7 @@
        (context routing/file-uri []
          (file-handler oid))
        (context routing/exam-session-uri []
-         (exam-session-handler oid))))))
+         (exam-session-handler oid))
+       (context routing/exam-date-uri []
+         (exam-date-handler oid))))))
+

--- a/src/yki/handler/routing.clj
+++ b/src/yki/handler/routing.clj
@@ -48,3 +48,4 @@
 
 (def code-api-root (str api-root "/code"))
 
+(def exam-date-uri "/exam-date")

--- a/src/yki/job/scheduled_tasks.clj
+++ b/src/yki/job/scheduled_tasks.clj
@@ -109,21 +109,16 @@
              (doseq [item (:queue exam-session)]
                (let [lang             (:lang item)
                      email            (:email item)
-                     created          (c/from-long (:created item))
                      exam-session-id  (:exam_session_id exam-session)
-                     last_notified    (:last_notified_at exam-session)
                      exam-session-url (url-helper :exam-session.url exam-session-id lang)
-                     reg-start-time   (t/plus  (c/from-long (:registration_start_date exam-session)) (t/hours 10))
-                     prequeue         (t/before? (util/set-timezone created) reg-start-time)
-                     notification     (if (and prequeue (nil? last_notified)) "prequeue_notification" "queue_notification")
                      language         (template-util/get-language url-helper (:language_code exam-session) lang)
                      level            (template-util/get-level url-helper (:level_code exam-session) lang)]
-                 (log/info "Queue handler triggered" notification "for email" email)
+                 (log/info "Sending notification to email" email)
                  (pgq/put email-q
                           {:recipients [email]
                            :created (System/currentTimeMillis)
-                           :subject (template-util/subject url-helper notification lang exam-session)
-                           :body (template-util/render url-helper notification
+                           :subject (template-util/subject url-helper "queue_notification" lang exam-session)
+                           :body (template-util/render url-helper "queue_notification"
                                                        lang
                                                        (assoc exam-session
                                                               :exam-session-url exam-session-url

--- a/src/yki/job/scheduled_tasks.clj
+++ b/src/yki/job/scheduled_tasks.clj
@@ -8,7 +8,6 @@
             [yki.boundary.exam-session-db :as exam-session-db]
             [yki.boundary.yki-register :as yki-register]
             [yki.util.template-util :as template-util]
-            [yki.util.common :as util]
             [yki.job.job-queue]
             [clj-time.coerce :as c]
             [clj-time.core :as t]

--- a/src/yki/middleware/auth.clj
+++ b/src/yki/middleware/auth.clj
@@ -137,8 +137,8 @@
     :on-error (fn [req _] (redirect-to-shibboleth req url-helper))}
    {:pattern #".*/api/registration.*"
     :handler participant-authenticated}
-    {:pattern #".*/api/exam-date/.*"
-     :handler oph-admin-access}
+   {:pattern #".*/api/exam-date/.*"
+    :handler oph-admin-access}
    {:pattern #".*/payment/formdata"
     :handler participant-authenticated}
    {:pattern #".*/payment/success"

--- a/src/yki/middleware/auth.clj
+++ b/src/yki/middleware/auth.clj
@@ -116,6 +116,8 @@
     :request-method :get}
    {:pattern #".*/api/virkailija/organizer/.*/exam-session.*"
     :handler {:and [(partial virkailija-authenticated db) {:or [oph-admin-access permission-to-organization]}]}}
+   {:pattern #".*/api/virkailija/organizer/.*/exam-date.*"
+    :handler (partial virkailija-authenticated db)}
    {:pattern #".*/api/virkailija/organizer"
     :handler (partial virkailija-authenticated db) ; authorized on database level
     :request-method :get}

--- a/src/yki/registration/registration.clj
+++ b/src/yki/registration/registration.clj
@@ -116,6 +116,7 @@
     (login-link-db/create-login-link! db
                                       (assoc login-link
                                              :code hashed))
+    (log/info "Login link created for " email ". Adding to email queue")
     (pgq/put email-q
              {:recipients [email]
               :created (System/currentTimeMillis)

--- a/src/yki/spec.clj
+++ b/src/yki/spec.clj
@@ -115,6 +115,7 @@
 ; post admission extensions for exam-session
 (s/def ::post_admission_quota      (s/nilable pos-int?))
 (s/def ::post_admission_start_date (s/nilable ::date-type))
+(s/def ::post_admission_end_date (s/nilable ::date-type))
 (s/def ::post_admission_active     boolean?)
 
 (s/def ::exam-session (s/keys :req-un [::session_date
@@ -133,14 +134,16 @@
                                        ::organizer_oid
                                        ::post_admission_quota
                                        ::post_admission_start_date
+                                       ::post_admission_end_date
                                        ::post_admission_active]))
+
 (s/def ::exam_sessions (s/coll-of ::exam-session))
 (s/def ::exam-sessions-response (s/keys :req-un [::exam_sessions]))
 (s/def ::from-param (s/keys :opt-un [::from]))
 
-(s/def ::post-admission-update (s/keys :req-un [::post_admission_start_date ::post_admission_quota]))
+(s/def ::post-admission-update (s/keys :req-un [::post_admission_start_date ::post_admission_end_date ::post_admission_quota]))
 
-(s/def ::post-admission-activation (s/keys :req-un [::post_admission_active]))
+(s/def ::post-admission-activation (s/keys :req-un [::post_admission_quota]))
 
 (s/def ::id-response (s/keys :req-un [::id]))
 

--- a/src/yki/spec.clj
+++ b/src/yki/spec.clj
@@ -32,10 +32,10 @@
 
 (s/def ::non-blank-string (s/and string? #(not (str/blank? %)) #(<= (count %) 2560)))
 (s/def ::registration-kind #{"POST_ADMISSION" "ADMISSION" "OTHER"})
-(s/def ::date         (st/spec
-                       {:spec (partial date?)
-                        :type :date-time
-                        :json-schema/default "2018-01-01T00:00:00Z"}))
+(s/def ::date-type         (st/spec
+                            {:spec (partial date?)
+                             :type :date-time
+                             :json-schema/default "2018-01-01T00:00:00Z"}))
 (s/def ::time         (s/and string? #(re-matches time-regex %)))
 (s/def ::email-type   (s/and string? #(re-matches email-regex %)))
 (s/def ::oid          (s/and string? #(re-matches oid-regex %)))
@@ -43,9 +43,9 @@
 (s/def ::email        ::email-type)
 
 ;; organizer
-(s/def ::agreement_start_date ::date)
-(s/def ::agreement_end_date   ::date)
-(s/def ::created              ::date)
+(s/def ::agreement_start_date ::date-type)
+(s/def ::agreement_end_date   ::date-type)
+(s/def ::created              ::date-type)
 (s/def ::contact_name         (s/and string? #(<= (count %) 256)))
 (s/def ::language_code        ::exam-language-code)
 (s/def ::level_code           (s/and string? #(<= (count %) 16)))
@@ -59,6 +59,8 @@
 (s/def ::external-id-type     (s/keys :req-un [::external_id]))
 (s/def ::language             (s/keys :req-un [::language_code]
                                       :opt-un [::level_code]))
+(s/def ::exam-date-language   (s/keys :req-un [::language_code
+                                               ::level_code]))
 (s/def ::attachment           (s/keys :req-un [::external_id
                                                ::created]))
 (s/def ::languages            (s/or :null nil? :array (s/coll-of ::language)))
@@ -100,19 +102,19 @@
 ;; exam-session
 (s/def ::organizer_oid              ::oid)
 (s/def ::office_oid                 (s/nilable ::oid))
-(s/def ::session_date               ::date)
+(s/def ::session_date               ::date-type)
 (s/def ::max_participants           pos-int?)
-(s/def ::published_at               (s/nilable ::date))
+(s/def ::published_at               (s/nilable ::date-type))
 (s/def ::participants               int?)
 (s/def ::exam_fee                   ::amount)
 (s/def ::open                       boolean?)
 (s/def ::queue_full                 boolean?)
 (s/def ::queue                      int?)
-(s/def ::from                       ::date)
+(s/def ::from                       ::date-type)
 (s/def ::days                       int?)
 ; post admission extensions for exam-session
 (s/def ::post_admission_quota      (s/nilable pos-int?))
-(s/def ::post_admission_start_date (s/nilable ::date))
+(s/def ::post_admission_start_date (s/nilable ::date-type))
 (s/def ::post_admission_active     boolean?)
 
 (s/def ::exam-session (s/keys :req-un [::session_date
@@ -143,21 +145,36 @@
 (s/def ::id-response (s/keys :req-un [::id]))
 
 ;; exam date
-(s/def ::exam_date                 ::date)
-(s/def ::registration_start_date   ::date)
-(s/def ::registration_end_date     ::date)
-(s/def ::post_admission_end_date   (s/nilable ::date))
+(s/def ::exam_date                 ::date-type)
+(s/def ::registration_start_date   ::date-type)
+(s/def ::registration_end_date     ::date-type)
+(s/def ::post_admission_end_date   (s/nilable ::date-type))
+(s/def ::post_admission_enabled boolean?)
+(s/def ::exam_session_count         int?)
+(s/def ::languages      (s/or :null nil? :array (s/coll-of ::exam-date-language)))
+
 (s/def ::exam-date-type (s/keys :req-un [::exam_date
                                          ::registration_start_date
                                          ::registration_end_date
+                                         ::languages]
+                                :opt-un [::id
+                                         ::post_admission_start_date
                                          ::post_admission_end_date
-                                         ::languages]))
+                                         ::post_admission_enabled
+                                         ::exam_session_count]))
+
 (s/def ::dates (s/coll-of ::exam-date-type))
+(s/def ::date      ::exam-date-type)
+(s/def ::single-exam-date-response (s/keys :req-un [::date]))
 (s/def ::exam-date-response (s/keys :req-un [::dates]))
 
 (s/def ::post-admission-end-date-update (s/keys :req-un [::post_admission_end_date]))
+(s/def ::exam-date-post-admission-update (s/keys :req-un [::post_admission_start_date ::post_admission_end_date ::post_admission_enabled]))
+
 
 ;; exam session queue
+
+
 (s/def ::to-queue-request (s/keys :req-un [::email]))
 
 ;; localisation
@@ -224,7 +241,7 @@
 (s/def ::nick_name (s/nilable ::non-blank-string))
 (s/def ::gender (s/nilable ::gender-code))
 (s/def ::nationalities (s/coll-of (s/and ::non-blank-string #(= (count %) 3))))
-(s/def ::birthdate (s/nilable ::date))
+(s/def ::birthdate (s/nilable ::date-type))
 (s/def ::post_office ::non-blank-string)
 (s/def ::nationality_desc ::non-blank-string)
 (s/def ::zip ::non-blank-string)

--- a/src/yki/util/audit_log.clj
+++ b/src/yki/util/audit_log.clj
@@ -21,6 +21,7 @@
 (def registration "registration")
 (def registration-init "registration-init")
 (def exam-session "exam-session")
+(def exam-date "exam-date")
 
 (defonce jsonParser (JsonParser.))
 

--- a/test/resources/exam_date.json
+++ b/test/resources/exam_date.json
@@ -1,0 +1,7 @@
+{
+	"exam_date": "2040-06-07",
+	"registration_start_date": "2040-01-01",
+	"registration_end_date": "2040-01-30",
+	"post_admission_end_date": "2040-05-30",
+	"languages": []
+}

--- a/test/resources/exam_sessions.json
+++ b/test/resources/exam_sessions.json
@@ -9,6 +9,8 @@
       "post_admission_active": false,
       "post_admission_start_date": null,
       "post_admission_end_date": null,
+      "post_admission_activated_at": null,
+      "post_admission_enabled": false,
       "location": [
         {
           "lang": "fi",

--- a/test/resources/init_post_registration_response.json
+++ b/test/resources/init_post_registration_response.json
@@ -8,6 +8,7 @@
     "registration_start_date": "2017-12-01",
     "open": true,
     "max_participants": 5,
+    "pa_participants": 1,
     "language_code": "fin",
     "office_oid": "1.2.3.4.5",
     "published_at": null,

--- a/test/resources/init_post_registration_response.json
+++ b/test/resources/init_post_registration_response.json
@@ -18,11 +18,13 @@
     "post_admission_end_date": "2039-12-31",
     "post_admission_active": true,
     "post_admission_quota": 20,
+    "post_admission_enabled": true,
+    "post_admission_activated_at": null,
     "location": [
       {
         "lang": "fi",
         "extra_information": null,
-        "post_office":"Espoo",
+        "post_office": "Espoo",
         "name": "Omenia",
         "other_location_info": "Other info",
         "street_address": "Upseerinkatu 11",

--- a/test/resources/init_registration_response.json
+++ b/test/resources/init_registration_response.json
@@ -8,6 +8,7 @@
     "registration_start_date": "2017-12-01",
     "open": true,
     "max_participants": 5,
+    "pa_participants": 0,
     "language_code": "fin",
     "office_oid": "1.2.3.4.5",
     "published_at": null,

--- a/test/resources/init_registration_response.json
+++ b/test/resources/init_registration_response.json
@@ -18,11 +18,13 @@
     "post_admission_end_date": null,
     "post_admission_active": false,
     "post_admission_quota": null,
+    "post_admission_activated_at": null,
+    "post_admission_enabled": false,
     "location": [
       {
         "lang": "fi",
         "extra_information": null,
-        "post_office":"Espoo",
+        "post_office": "Espoo",
         "name": "Omenia",
         "other_location_info": "Other info",
         "street_address": "Upseerinkatu 11",

--- a/test/resources/language_eng.json
+++ b/test/resources/language_eng.json
@@ -1,0 +1,6 @@
+[
+	{
+		"language_code": "eng",
+		"level_code": "YLIN"
+	}
+]

--- a/test/resources/language_fin.json
+++ b/test/resources/language_fin.json
@@ -1,0 +1,6 @@
+[
+	{
+		"language_code": "fin",
+		"level_code": "YLIN"
+	}
+]

--- a/test/resources/languages.json
+++ b/test/resources/languages.json
@@ -1,0 +1,10 @@
+[
+	{
+		"language_code": "fin",
+		"level_code": "YLIN"
+	},
+	{
+		"language_code": "eng",
+		"level_code": "YLIN"
+	}
+]

--- a/test/yki/handler/base_test.clj
+++ b/test/yki/handler/base_test.clj
@@ -14,6 +14,7 @@
             [yki.handler.login-link :as login-link]
             [yki.handler.routing :as routing]
             [yki.handler.exam-session]
+            [yki.handler.exam-date]
             [yki.handler.file]
             [yki.handler.auth]
             [yki.job.job-queue]
@@ -52,6 +53,9 @@
 
 (def exam-session
   (slurp "test/resources/exam_session.json"))
+
+(def exam-date
+  (slurp "test/resources/exam_date.json"))
 
 (def organization
   (slurp "test/resources/organization.json"))
@@ -205,7 +209,7 @@
 
 (defn insert-organizer [oid]
   (jdbc/execute! @embedded-db/conn (str "INSERT INTO organizer (oid, agreement_start_date, agreement_end_date, contact_name, contact_email, contact_phone_number, extra)
-        VALUES (" oid ", '2018-01-01', '2089-01-01', 'name', 'email@oph.fi', 'phone', 'shared@oph.fi')")))
+        VALUES (" oid ", '2018-01-01', '2089-01-01', 'name', 'email@oph.fi', 'phone', 'shared@oph.fi') ON CONFLICT DO NOTHING")))
 
 (defn insert-payment-config [oid]
   (jdbc/execute! @embedded-db/conn (str "INSERT INTO payment_config (organizer_id, merchant_id, merchant_secret)
@@ -222,15 +226,21 @@
   (jdbc/execute! @embedded-db/conn "INSERT INTO exam_date(exam_date, registration_start_date, registration_end_date) VALUES ('2039-05-02', '2039-01-01', '2039-03-01')")
   (jdbc/execute! @embedded-db/conn "INSERT INTO exam_date(exam_date, registration_start_date, registration_end_date, post_admission_end_date) VALUES ('2039-05-10', '2039-01-01', '2039-03-01', '2039-04-15')"))
 
-(defn insert-exam-history-dates [exam-date reg-start reg-end]
+(defn insert-custom-exam-date [exam-date reg-start reg-end]
   (jdbc/execute! @embedded-db/conn (str "INSERT INTO exam_date(exam_date, registration_start_date, registration_end_date) VALUES ('" exam-date "', '" reg-start "', '" reg-end "')")))
 
 (def select-participant "(SELECT id from participant WHERE external_user_id = 'test@user.com')")
 
 (def select-exam-session "(SELECT id from exam_session WHERE max_participants = 5)")
 
-(defn select-exam-date-id [exam-date]
+(defn select-exam-date [id]
+  (str "(SELECT * from exam_date WHERE id=" id ")"))
+
+(defn select-exam-date-id-by-date [exam-date]
   (str "(SELECT id from exam_date WHERE exam_date='" exam-date "')"))
+
+(defn select-exam-date-languages-by-date-id [exam-date-id]
+  (str "(SELECT language_code, level_code from exam_date_language WHERE exam_date_id='" exam-date-id "' AND deleted_at IS NULL)"))
 
 (defn insert-exam-session
   [exam-date-id oid count]
@@ -355,7 +365,7 @@
 (defn insert-post-admission-registration
   [oid count quota]
   (jdbc/execute! @embedded-db/conn (str "INSERT INTO exam_date(exam_date, registration_start_date, registration_end_date, post_admission_end_date) VALUES ('" (two-weeks-from-now) "', '2019-08-01', '2019-10-01', '" (two-weeks-from-now) "')"))
-  (let [exam-date-id (:id (select-one (select-exam-date-id (two-weeks-from-now))))
+  (let [exam-date-id (:id (select-one (select-exam-date-id-by-date (two-weeks-from-now))))
         office-oid (-> oid (clojure.string/replace #"'" "") (str ".5"))
         insert-exam (jdbc/execute! @embedded-db/conn (str "INSERT INTO exam_session (organizer_id,
           language_code,
@@ -390,6 +400,9 @@
                                                                      :url-helper url-helper
                                                                      :email-q (email-q)
                                                                      :data-sync-q  (data-sync-q)})
+
+        exam-date-handler (ig/init-key :yki.handler/exam-date {:db db})
+
         file-store (ig/init-key :yki.boundary.files/liiteri-file-store {:url-helper url-helper})
         auth (ig/init-key :yki.middleware.no-auth/with-authentication {:url-helper url-helper
                                                                        :db db
@@ -407,6 +420,7 @@
                                                                                        :access-log (access-log)
                                                                                        :url-helper url-helper
                                                                                        :exam-session-handler exam-session-handler
+                                                                                       :exam-date-handler exam-date-handler
                                                                                        :file-handler file-handler}))]
     (routes organizer-handler auth-handler)))
 

--- a/test/yki/handler/exam_date_public_test.clj
+++ b/test/yki/handler/exam_date_public_test.clj
@@ -1,0 +1,24 @@
+(ns yki.handler.exam-date-public-test
+  (:require [clojure.test :refer :all]
+            [integrant.core :as ig]
+            [ring.mock.request :as mock]
+            [yki.handler.base-test :as base]
+            [compojure.api.sweet :refer :all]
+            [jsonista.core :as j]
+            [clojure.java.jdbc :as jdbc]
+            [yki.embedded-db :as embedded-db]
+            [yki.handler.routing :as routing]
+            [yki.handler.exam-date-public]))
+
+(use-fixtures :once (join-fixtures [embedded-db/with-postgres embedded-db/with-migration embedded-db/with-transaction]))
+
+(defn- send-request [request]
+  (let [handler (api (ig/init-key :yki.handler/exam-date-public {:db (base/db)}))]
+    (handler request)))
+
+(deftest get-exam-dates-test
+  (let [request (mock/request :get routing/exam-date-api-root)
+        response (send-request request)]
+    (testing "should return 200"
+      (is (= (:status response) 200)))))
+

--- a/test/yki/handler/exam_date_test.clj
+++ b/test/yki/handler/exam_date_test.clj
@@ -45,10 +45,11 @@
     (base/send-request-with-tx request)))
 
 (deftest get-exam-dates-test
-  (let [request (mock/request :get (str routing/organizer-api-root "/1.2.3.4/exam-date"))
-        response (base/send-request-with-tx request)]
-    (testing "should return 200"
-      (is (= (:status response) 200)))))
+  (testing "can get exam dates"
+    (let [request (mock/request :get (str routing/organizer-api-root "/1.2.3.4/exam-date"))
+          response (base/send-request-with-tx request)]
+      (testing "should return 200"
+        (is (= (:status response) 200))))))
 
 (deftest exam-date-new-date-test
 
@@ -120,7 +121,7 @@
       (is (= (get-success-status response-body) false))
       (is (= (:status response) 409)))))
 
-(deftest ^:test-refresh/focus exam-date-language-test
+(deftest exam-date-language-test
 
   (base/insert-organizer "'1.2.3.4'")
 

--- a/test/yki/handler/exam_date_test.clj
+++ b/test/yki/handler/exam_date_test.clj
@@ -153,13 +153,13 @@
         (is (= (:status response) 200))
         (is (= 2 (count (base/select (base/select-exam-date-languages-by-date-id exam-date-id)))))))
 
-    (testing "cannot add a language-level pair to a exam date if it already exists"
+    (testing "can post a language-level pair to a exam date even if it already exists"
       (let [languages (slurp "test/resources/languages.json")
             exam-date-id (get-exam-date-id-by-date "2039-10-12")
             response (post-exam-date-languages exam-date-id languages)
             response-body (base/body-as-json response)]
-        (is (= (:status response) 409))
-        (is (= (get-success-status response-body) false))
+        (is (= (:status response) 200))
+        (is (= (get-success-status response-body) true))
         (is (= 2 (count (base/select (base/select-exam-date-languages-by-date-id exam-date-id))))))))
 
   (let [delete-exam-date-languages (fn [id exam-date-languages]

--- a/test/yki/handler/exam_date_test.clj
+++ b/test/yki/handler/exam_date_test.clj
@@ -8,17 +8,178 @@
             [clojure.java.jdbc :as jdbc]
             [yki.embedded-db :as embedded-db]
             [yki.handler.routing :as routing]
-            [yki.handler.exam-date]))
+            [yki.handler.exam-date-public]))
 
 (use-fixtures :once (join-fixtures [embedded-db/with-postgres embedded-db/with-migration embedded-db/with-transaction]))
 
-(defn- send-request [request]
-  (let [handler (api (ig/init-key :yki.handler/exam-date {:db (base/db)}))]
-    (handler request)))
+(defn- get-success-status [response-body]
+  (get-in response-body ["success"]))
+
+(defn- create-exam-date-entry [new-values]
+  (reduce-kv (fn [entry k v]
+               (base/change-entry entry (name k) v))
+             base/exam-date new-values))
+
+(defn- get-exam-date [id]
+  (let [request (-> (mock/request :get (str routing/organizer-api-root (str "/1.2.3.4/exam-date/" id)))
+                    (mock/content-type "application/json; charset=UTF-8"))]
+    (base/send-request-with-tx request)))
+
+(defn- post-exam-date [exam-date-entry]
+  (let [request (-> (mock/request :post (str routing/organizer-api-root "/1.2.3.4/exam-date") exam-date-entry)
+                    (mock/content-type "application/json; charset=UTF-8"))]
+    (base/send-request-with-tx request)))
+
+(defn- delete-exam-date [id]
+  (let [request (-> (mock/request :delete (str routing/organizer-api-root (str "/1.2.3.4/exam-date/" id))))]
+    (base/send-request-with-tx request)))
+
+(defn- post-exam-date-language [id exam-date-languages]
+  (let [request (-> (mock/request :post (str routing/organizer-api-root (str "/1.2.3.4/exam-date/" id "/languages")) exam-date-languages)
+                    (mock/content-type "application/json; charset=UTF-8"))]
+    (base/send-request-with-tx request)))
+
+(defn- delete-exam-date-language [id exam-date-languages]
+  (let [request (-> (mock/request :delete (str routing/organizer-api-root (str "/1.2.3.4/exam-date/" id "/languages")) exam-date-languages)
+                    (mock/content-type "application/json; charset=UTF-8"))]
+    (base/send-request-with-tx request)))
 
 (deftest get-exam-dates-test
-  (let [request (mock/request :get routing/exam-date-api-root)
-        response (send-request request)]
+  (let [request (mock/request :get (str routing/organizer-api-root "/1.2.3.4/exam-date"))
+        response (base/send-request-with-tx request)]
     (testing "should return 200"
       (is (= (:status response) 200)))))
 
+(deftest exam-date-new-date-test
+
+  (base/insert-organizer "'1.2.3.4'")
+
+  (testing "creating a new exam date adds a new exam date entity to the system"
+    (let [new-dates {:exam_date "2041-06-07"}
+          exam-date-entry (create-exam-date-entry new-dates)
+          response (post-exam-date exam-date-entry)
+          response-body (base/body-as-json response)
+          date-id (get-in response-body ["id"])]
+      (is (= (:status response) 200))
+      (is (= date-id (:id (base/select-one (base/select-exam-date-id-by-date (:exam_date new-dates))))))))
+
+  (testing "cannot create a new exam date if same date already exists"
+    (let [new-dates {:exam_date "2041-06-07"}
+          exam-date-entry (create-exam-date-entry new-dates)
+          response (post-exam-date exam-date-entry)
+          response-body (base/body-as-json response)]
+      (is (= (get-success-status response-body) false))
+      (is (= (:status response) 409))))
+
+  (testing "cannot create a new exam date when registration end date is before registration start date"
+    (let [new-dates {:exam_date "2041-06-08"
+                     :registration_start_date "2041-03-07"
+                     :registration_end_date "2041-03-01"}
+          exam-date-entry (create-exam-date-entry new-dates)
+          response (post-exam-date exam-date-entry)
+          response-body (base/body-as-json response)]
+      (is (= (get-success-status response-body) false))
+      (is (= (:status response) 409))))
+
+  (testing "cannot create a new exam date when registration end date is not before exam date"
+    (let [new-dates {:exam_date "2041-06-09"
+                     :registration_start_date "2041-06-01"
+                     :registration_end_date "2041-06-11"}
+          exam-date-entry (create-exam-date-entry new-dates)
+          response (post-exam-date exam-date-entry)
+          response-body (base/body-as-json response)]
+      (is (= (get-success-status response-body) false))
+      (is (= (:status response) 409)))))
+
+(deftest exam-date-delete-date-test
+  (base/insert-organizer "'1.2.3.4'")
+
+  (let [new-dates {:exam_date "2040-06-07"}
+        exam-date-entry (create-exam-date-entry new-dates)]
+    (post-exam-date exam-date-entry))
+
+  (testing "delete sets deleted_at timestamp to exam date"
+    (let [date-id (:id (base/select-one (base/select-exam-date-id-by-date "2040-06-07")))
+          response (delete-exam-date date-id)]
+      (is (not (nil? (:deleted_at (base/select-one (base/select-exam-date date-id))))))
+      (is (= (:status response) 200))))
+
+  (testing "deleted exam date is not returned by get"
+    (let [date-id (:id (base/select-one (base/select-exam-date-id-by-date "2040-06-07")))
+          response (get-exam-date date-id)
+          response-body (base/body-as-json response)]
+      (is (= (get-success-status response-body) false))
+      (is (= (:status response) 404))))
+
+  (testing "cannot delete an exam date that has exam sessions assigned to it"
+    (base/insert-custom-exam-date "2039-10-01" "2039-10-01" "2039-10-30")
+    (let [date-id (:id (base/select-one (base/select-exam-date-id-by-date "2039-10-01")))
+          insert-session (base/insert-exam-session date-id "'1.2.3.4'" 5)
+          response (delete-exam-date date-id)
+          response-body (base/body-as-json response)]
+      (is (= (get-success-status response-body) false))
+      (is (= (:status response) 409)))))
+
+(deftest ^:test-refresh/focus exam-date-language-test
+
+  (base/insert-organizer "'1.2.3.4'")
+
+  (testing "can add languages to the exam date on exam date creation"
+    (let [languages (j/read-value (slurp "test/resources/languages.json"))
+          new-dates {:exam_date "2040-06-15"
+                     :languages languages}
+          exam-date-entry (create-exam-date-entry new-dates)
+          response (post-exam-date exam-date-entry)
+          response-body (base/body-as-json response)
+          date-id (get-in response-body ["id"])
+          exam-date (base/select-one (base/select-exam-date-id-by-date (:exam_date new-dates)))]
+      (is (= (:status response) 200))
+      (is (= date-id (:id exam-date)))
+      (is (= 2 (count (base/select (base/select-exam-date-languages-by-date-id date-id)))))))
+
+  (testing "languages are deleted on exam date delete"
+    (let [exam-date-id (:id (base/select-one (base/select-exam-date-id-by-date "2040-06-15")))
+          response (delete-exam-date exam-date-id)]
+      (is (= (:status response) 200))
+      (is (not (nil? (:deleted_at (base/select-one (base/select-exam-date exam-date-id))))))
+      (is (= 0 (count (base/select (base/select-exam-date-languages-by-date-id exam-date-id)))))))
+
+  (testing "can add a language to an existing exam date"
+    (base/insert-custom-exam-date "2039-10-12" "2039-10-01" "2039-10-30")
+    (let [languages (slurp "test/resources/languages.json")
+          exam-date-id (:id (base/select-one (base/select-exam-date-id-by-date "2039-10-12")))
+          response (post-exam-date-language exam-date-id languages)]
+      (is (= (:status response) 200))
+      (is (= 2 (count (base/select (base/select-exam-date-languages-by-date-id exam-date-id)))))))
+
+  (testing "cannot add a language-level pair to a exam date if it already exists"
+    (let [languages (slurp "test/resources/languages.json")
+          exam-date-id (:id (base/select-one (base/select-exam-date-id-by-date "2039-10-12")))
+          response (post-exam-date-language exam-date-id languages)
+          response-body (base/body-as-json response)]
+      (is (= (:status response) 409))
+      (is (= (get-success-status response-body) false))
+      (is (= 2 (count (base/select (base/select-exam-date-languages-by-date-id exam-date-id)))))))
+
+  (testing "can delete a language from an existing exam date"
+    (let [language (slurp "test/resources/language_fin.json")
+          exam-date-id (:id (base/select-one (base/select-exam-date-id-by-date "2039-10-12")))
+          response (delete-exam-date-language exam-date-id language)]
+      (is (= (:status response) 200))
+      (is (= 1 (count (base/select (base/select-exam-date-languages-by-date-id exam-date-id)))))))
+
+  (testing "cannot delete a language from an exam date that has exam sessions assigned to it"
+    (let [exam-date-id (:id (base/select-one (base/select-exam-date-id-by-date "2039-10-12")))
+          language (slurp "test/resources/language_eng.json")
+          insert-session (base/insert-exam-session exam-date-id "'1.2.3.4'" 5)
+          response (delete-exam-date-language exam-date-id language)
+          response-body (base/body-as-json response)]
+      (is (= (:status response) 409))
+      (is (= (get-success-status response-body) false))
+      (is (= 1 (count (base/select (base/select-exam-date-languages-by-date-id exam-date-id))))))))
+
+(deftest exam-date-post-admission-configure-test
+  (testing "can configure post admission for the exam date")
+  (testing "cannot add a post admission start date that is before it's end date")
+  (testing "cannot add a post admission start date that is before registration end")
+  (testing "cannot add a post admission end date that is after exam date"))

--- a/test/yki/handler/exam_date_test.clj
+++ b/test/yki/handler/exam_date_test.clj
@@ -15,10 +15,16 @@
 (defn- get-success-status [response-body]
   (get-in response-body ["success"]))
 
-(defn- create-exam-date-entry [new-values]
+(defn- create-new-entry [orig-entry new-values]
   (reduce-kv (fn [entry k v]
                (base/change-entry entry (name k) v))
-             base/exam-date new-values))
+             orig-entry new-values))
+
+(defn- create-exam-date-entry [new-values]
+  (create-new-entry base/exam-date new-values))
+
+(defn- get-exam-date-id-by-date [exam-date]
+  (:id (base/select-one (base/select-exam-date-id-by-date exam-date))))
 
 (defn- get-exam-date [id]
   (let [request (-> (mock/request :get (str routing/organizer-api-root (str "/1.2.3.4/exam-date/" id)))
@@ -32,16 +38,6 @@
 
 (defn- delete-exam-date [id]
   (let [request (-> (mock/request :delete (str routing/organizer-api-root (str "/1.2.3.4/exam-date/" id))))]
-    (base/send-request-with-tx request)))
-
-(defn- post-exam-date-language [id exam-date-languages]
-  (let [request (-> (mock/request :post (str routing/organizer-api-root (str "/1.2.3.4/exam-date/" id "/languages")) exam-date-languages)
-                    (mock/content-type "application/json; charset=UTF-8"))]
-    (base/send-request-with-tx request)))
-
-(defn- delete-exam-date-language [id exam-date-languages]
-  (let [request (-> (mock/request :delete (str routing/organizer-api-root (str "/1.2.3.4/exam-date/" id "/languages")) exam-date-languages)
-                    (mock/content-type "application/json; charset=UTF-8"))]
     (base/send-request-with-tx request)))
 
 (deftest get-exam-dates-test
@@ -62,7 +58,7 @@
           response-body (base/body-as-json response)
           date-id (get-in response-body ["id"])]
       (is (= (:status response) 200))
-      (is (= date-id (:id (base/select-one (base/select-exam-date-id-by-date (:exam_date new-dates))))))))
+      (is (= date-id (get-exam-date-id-by-date (:exam_date new-dates))))))
 
   (testing "cannot create a new exam date if same date already exists"
     (let [new-dates {:exam_date "2041-06-07"}
@@ -100,13 +96,13 @@
     (post-exam-date exam-date-entry))
 
   (testing "delete sets deleted_at timestamp to exam date"
-    (let [date-id (:id (base/select-one (base/select-exam-date-id-by-date "2040-06-07")))
+    (let [date-id (get-exam-date-id-by-date "2040-06-07")
           response (delete-exam-date date-id)]
       (is (not (nil? (:deleted_at (base/select-one (base/select-exam-date date-id))))))
       (is (= (:status response) 200))))
 
   (testing "deleted exam date is not returned by get"
-    (let [date-id (:id (base/select-one (base/select-exam-date-id-by-date "2040-06-07")))
+    (let [date-id (get-exam-date-id-by-date "2040-06-07")
           response (get-exam-date date-id)
           response-body (base/body-as-json response)]
       (is (= (get-success-status response-body) false))
@@ -114,7 +110,7 @@
 
   (testing "cannot delete an exam date that has exam sessions assigned to it"
     (base/insert-custom-exam-date "2039-10-01" "2039-10-01" "2039-10-30")
-    (let [date-id (:id (base/select-one (base/select-exam-date-id-by-date "2039-10-01")))
+    (let [date-id (get-exam-date-id-by-date "2039-10-01")
           insert-session (base/insert-exam-session date-id "'1.2.3.4'" 5)
           response (delete-exam-date date-id)
           response-body (base/body-as-json response)]
@@ -125,62 +121,141 @@
 
   (base/insert-organizer "'1.2.3.4'")
 
-  (testing "can add languages to the exam date on exam date creation"
-    (let [languages (j/read-value (slurp "test/resources/languages.json"))
-          new-dates {:exam_date "2040-06-15"
-                     :languages languages}
-          exam-date-entry (create-exam-date-entry new-dates)
-          response (post-exam-date exam-date-entry)
-          response-body (base/body-as-json response)
-          date-id (get-in response-body ["id"])
-          exam-date (base/select-one (base/select-exam-date-id-by-date (:exam_date new-dates)))]
-      (is (= (:status response) 200))
-      (is (= date-id (:id exam-date)))
-      (is (= 2 (count (base/select (base/select-exam-date-languages-by-date-id date-id)))))))
+  (let [post-exam-date-languages (fn [id exam-date-languages]
+                                   (let [request (-> (mock/request :post (str routing/organizer-api-root (str "/1.2.3.4/exam-date/" id "/languages")) exam-date-languages)
+                                                     (mock/content-type "application/json; charset=UTF-8"))]
+                                     (base/send-request-with-tx request)))]
+    (testing "can add languages to the exam date on exam date creation"
+      (let [languages (j/read-value (slurp "test/resources/languages.json"))
+            new-dates {:exam_date "2040-06-15"
+                       :languages languages}
+            exam-date-entry (create-exam-date-entry new-dates)
+            response (post-exam-date exam-date-entry)
+            response-body (base/body-as-json response)
+            date-id (get-in response-body ["id"])
+            exam-date (base/select-one (base/select-exam-date-id-by-date (:exam_date new-dates)))]
+        (is (= (:status response) 200))
+        (is (= date-id (:id exam-date)))
+        (is (= 2 (count (base/select (base/select-exam-date-languages-by-date-id date-id)))))))
 
-  (testing "languages are deleted on exam date delete"
-    (let [exam-date-id (:id (base/select-one (base/select-exam-date-id-by-date "2040-06-15")))
-          response (delete-exam-date exam-date-id)]
-      (is (= (:status response) 200))
-      (is (not (nil? (:deleted_at (base/select-one (base/select-exam-date exam-date-id))))))
-      (is (= 0 (count (base/select (base/select-exam-date-languages-by-date-id exam-date-id)))))))
+    (testing "languages are deleted on exam date delete"
+      (let [exam-date-id (get-exam-date-id-by-date "2040-06-15")
+            response (delete-exam-date exam-date-id)]
+        (is (= (:status response) 200))
+        (is (not (nil? (:deleted_at (base/select-one (base/select-exam-date exam-date-id))))))
+        (is (= 0 (count (base/select (base/select-exam-date-languages-by-date-id exam-date-id)))))))
 
-  (testing "can add a language to an existing exam date"
-    (base/insert-custom-exam-date "2039-10-12" "2039-10-01" "2039-10-30")
-    (let [languages (slurp "test/resources/languages.json")
-          exam-date-id (:id (base/select-one (base/select-exam-date-id-by-date "2039-10-12")))
-          response (post-exam-date-language exam-date-id languages)]
-      (is (= (:status response) 200))
-      (is (= 2 (count (base/select (base/select-exam-date-languages-by-date-id exam-date-id)))))))
+    (testing "can add a language to an existing exam date"
+      (base/insert-custom-exam-date "2039-10-12" "2039-10-01" "2039-10-30")
+      (let [languages (slurp "test/resources/languages.json")
+            exam-date-id (get-exam-date-id-by-date "2039-10-12")
+            response (post-exam-date-languages exam-date-id languages)]
+        (is (= (:status response) 200))
+        (is (= 2 (count (base/select (base/select-exam-date-languages-by-date-id exam-date-id)))))))
 
-  (testing "cannot add a language-level pair to a exam date if it already exists"
-    (let [languages (slurp "test/resources/languages.json")
-          exam-date-id (:id (base/select-one (base/select-exam-date-id-by-date "2039-10-12")))
-          response (post-exam-date-language exam-date-id languages)
-          response-body (base/body-as-json response)]
-      (is (= (:status response) 409))
-      (is (= (get-success-status response-body) false))
-      (is (= 2 (count (base/select (base/select-exam-date-languages-by-date-id exam-date-id)))))))
+    (testing "cannot add a language-level pair to a exam date if it already exists"
+      (let [languages (slurp "test/resources/languages.json")
+            exam-date-id (get-exam-date-id-by-date "2039-10-12")
+            response (post-exam-date-languages exam-date-id languages)
+            response-body (base/body-as-json response)]
+        (is (= (:status response) 409))
+        (is (= (get-success-status response-body) false))
+        (is (= 2 (count (base/select (base/select-exam-date-languages-by-date-id exam-date-id))))))))
 
-  (testing "can delete a language from an existing exam date"
-    (let [language (slurp "test/resources/language_fin.json")
-          exam-date-id (:id (base/select-one (base/select-exam-date-id-by-date "2039-10-12")))
-          response (delete-exam-date-language exam-date-id language)]
-      (is (= (:status response) 200))
-      (is (= 1 (count (base/select (base/select-exam-date-languages-by-date-id exam-date-id)))))))
+  (let [delete-exam-date-languages (fn [id exam-date-languages]
+                                     (let [request (-> (mock/request :delete (str routing/organizer-api-root (str "/1.2.3.4/exam-date/" id "/languages")) exam-date-languages)
+                                                       (mock/content-type "application/json; charset=UTF-8"))]
+                                       (base/send-request-with-tx request)))]
+    (testing "can delete a language from an existing exam date"
+      (let [language (slurp "test/resources/language_fin.json")
+            exam-date-id (get-exam-date-id-by-date "2039-10-12")
+            response (delete-exam-date-languages exam-date-id language)]
+        (is (= (:status response) 200))
+        (is (= 1 (count (base/select (base/select-exam-date-languages-by-date-id exam-date-id)))))))
 
-  (testing "cannot delete a language from an exam date that has exam sessions assigned to it"
-    (let [exam-date-id (:id (base/select-one (base/select-exam-date-id-by-date "2039-10-12")))
-          language (slurp "test/resources/language_eng.json")
-          insert-session (base/insert-exam-session exam-date-id "'1.2.3.4'" 5)
-          response (delete-exam-date-language exam-date-id language)
-          response-body (base/body-as-json response)]
-      (is (= (:status response) 409))
-      (is (= (get-success-status response-body) false))
-      (is (= 1 (count (base/select (base/select-exam-date-languages-by-date-id exam-date-id))))))))
+    (testing "cannot delete a language from an exam date that has exam sessions assigned to it"
+      (let [exam-date-id (get-exam-date-id-by-date "2039-10-12")
+            language (slurp "test/resources/language_eng.json")
+            insert-session (base/insert-exam-session exam-date-id "'1.2.3.4'" 5)
+            response (delete-exam-date-languages exam-date-id language)
+            response-body (base/body-as-json response)]
+        (is (= (:status response) 409))
+        (is (= (get-success-status response-body) false))
+        (is (= 1 (count (base/select (base/select-exam-date-languages-by-date-id exam-date-id)))))))))
 
 (deftest exam-date-post-admission-configure-test
-  (testing "can configure post admission for the exam date")
-  (testing "cannot add a post admission start date that is before it's end date")
-  (testing "cannot add a post admission start date that is before registration end")
-  (testing "cannot add a post admission end date that is after exam date"))
+
+  (base/insert-custom-exam-date "2042-06-01" "2042-01-01" "2042-01-30")
+  (let [configure-post-admission (fn [id configuration]
+                                   (let [request (-> (mock/request :post (str routing/organizer-api-root (str "/1.2.3.4/exam-date/" id "/post-admission")) configuration)
+                                                     (mock/content-type "application/json; charset=UTF-8"))]
+                                     (base/send-request-with-tx request)))
+        exam-date-id (get-exam-date-id-by-date "2042-06-01")]
+
+    (testing "can configure post admission for the exam date"
+      (let [post-admission {:post_admission_start_date "2042-02-01"
+                            :post_admission_end_date "2042-02-28"
+                            :post_admission_enabled false}
+            configuration (create-new-entry "{}" post-admission)
+            response (configure-post-admission exam-date-id configuration)
+            exam-date (base/select-one (base/select-exam-date exam-date-id))]
+        (is (= (:status response) 200))
+        (is (= (:post_admission_end_date exam-date) (:post_admission_end_date post-admission)))
+        (is (= (:post_admission_start_date exam-date) (:post_admission_start_date post-admission)))
+        (is (= (:post_admission_enabled exam-date) (:post_admission_enabled post-admission)))))
+
+    (testing "cannot add a post admission start date that is before it's end date"
+      (let [post-admission {:post_admission_start_date "2042-02-28"
+                            :post_admission_end_date "2042-02-01"
+                            :post_admission_enabled false}
+            configuration (create-new-entry "{}" post-admission)
+            response (configure-post-admission exam-date-id configuration)
+            response-body (base/body-as-json response)]
+        (is (= (:status response) 409))
+        (is (= (get-success-status response-body) false))))
+
+    (testing "cannot add a post admission start date that is before registration end"
+      (let [post-admission {:post_admission_start_date "2042-01-28"
+                            :post_admission_end_date "2042-02-28"
+                            :post_admission_enabled false}
+            configuration (create-new-entry "{}" post-admission)
+            response (configure-post-admission exam-date-id configuration)
+            response-body (base/body-as-json response)]
+        (is (= (:status response) 409))
+        (is (= (get-success-status response-body) false))))
+
+    (testing "cannot add a post admission end date that is after exam date"
+      (let [post-admission {:post_admission_start_date "2042-02-28"
+                            :post_admission_end_date "2042-06-28"
+                            :post_admission_enabled false}
+            configuration (create-new-entry "{}" post-admission)
+            response (configure-post-admission exam-date-id configuration)
+            response-body (base/body-as-json response)]
+        (is (= (:status response) 409))
+        (is (= (get-success-status response-body) false)))))
+
+  (base/insert-custom-exam-date "2042-12-01" "2042-06-01" "2042-06-30")
+  (let [toggle-post-admission (fn [id status-endpoint]
+                                (let [request (-> (mock/request :post (str routing/organizer-api-root (str "/1.2.3.4/exam-date/" id "/post-admission/" status-endpoint)))
+                                                  (mock/content-type "appll.ö,_Bication/json; charset=UTF-8"))]
+                                  (base/send-request-with-tx request)))
+        configured-exam-date-id (get-exam-date-id-by-date "2042-06-01")
+        new-exam-date-id (get-exam-date-id-by-date "2042-12-01")]
+
+    (testing "can enable post admission"
+      (let [response (toggle-post-admission configured-exam-date-id "enable")
+            exam-date (base/select-one (base/select-exam-date configured-exam-date-id))]
+        (is (= (:status response) 200))
+        (is (= (:post_admission_enabled exam-date) true))))
+
+    (testing "can disable post admission"
+      (let [response (toggle-post-admission configured-exam-date-id "disable")
+            exam-date (base/select-one (base/select-exam-date configured-exam-date-id))]
+        (is (= (:status response) 200))
+        (is (= (:post_admission_enabled exam-date) false))))
+
+    (testing "cannot toggle post admission if dates have not been configured"
+      (let [response (toggle-post-admission new-exam-date-id "enable")
+            exam-date (base/select-one (base/select-exam-date new-exam-date-id))]
+        (is (= (:status response) 409))
+        (is (= (:post_admission_enabled exam-date) false))))))

--- a/test/yki/handler/exam_session_test.clj
+++ b/test/yki/handler/exam_session_test.clj
@@ -150,17 +150,8 @@
         iterate-exam-dates (fn [dates] (for [d dates] (insert-dates d)))]
     (doall (iterate-exam-dates exam-dates)))
 
-  (testing "exam session history endpoint should return exam session history from past six months"
-    (let [request (mock/request :get (str routing/organizer-api-root "/1.2.3.4/exam-session/history?from=2040-04-01T00:00:00Z"))
-          response (base/send-request-with-tx request)
-          response-body (base/body-as-json response)]
-      (is (= (get (:headers response) "Content-Type") "application/json; charset=utf-8"))
-      (is (= (:status response) 200))
-      (is (= (get-exam-date response-body "2039-12-01") "2039-12-01"))
-      (is (= (get-exam-date response-body "2039-10-01") nil))))
-
-  (testing "exam session history endpoint with 'days' parameter should return limited sessions from past days"
-    (let [request (mock/request :get (str routing/organizer-api-root "/1.2.3.4/exam-session/history?from=2040-06-01T00:00:00Z&days=100"))
+  (testing "exam session endpoint with 'days' parameter should return sessions from past days"
+    (let [request (mock/request :get (str routing/organizer-api-root "/1.2.3.4/exam-session?from=2040-06-01T00:00:00Z&days=100"))
           response (base/send-request-with-tx request)
           response-body (base/body-as-json response)]
       (is (= (get (:headers response) "Content-Type") "application/json; charset=utf-8"))

--- a/test/yki/handler/exam_session_test.clj
+++ b/test/yki/handler/exam_session_test.clj
@@ -140,11 +140,11 @@
                     ["2039-12-01" "2040-11-01" "2040-11-30"]
                     ["2039-10-01" "2039-10-01" "2039-10-30"]]
         date-id (fn [date] (-> date
-                               (base/select-exam-date-id)
+                               (base/select-exam-date-id-by-date)
                                (base/select-one)
                                :id))
         insert-dates (fn [dates] (let [[exam-date reg-start reg-end] dates]
-                                   (base/insert-exam-history-dates exam-date reg-start reg-end)
+                                   (base/insert-custom-exam-date exam-date reg-start reg-end)
                                    (base/insert-exam-session (date-id exam-date) "'1.2.3.4'" 5)
                                    (base/insert-exam-session-location-by-date exam-date "fi")))
         iterate-exam-dates (fn [dates] (for [d dates] (insert-dates d)))]

--- a/test/yki/handler/exam_session_test.clj
+++ b/test/yki/handler/exam_session_test.clj
@@ -22,6 +22,11 @@
         get-date (fn [r] (some #{r} date-map))]
     (get-date date)))
 
+(defn- get-new-entry [orig-entry new-values]
+  (reduce-kv (fn [entry k v]
+               (base/change-entry entry (name k) v))
+             orig-entry new-values))
+
 (deftest exam-session-validation-test
   (let [invalid-exam-session (base/change-entry base/exam-session "session_date" "NOT_A_DATE")
         request (-> (mock/request :post (str routing/organizer-api-root "/1.2.3.4/exam-session") invalid-exam-session)
@@ -37,6 +42,7 @@
   (base/insert-organizer "'1.2.3.4'")
   (base/insert-languages "'1.2.3.4'")
   (base/insert-exam-dates)
+  (base/insert-post-admission-dates)
 
   (testing "post exam session endpoint should add valid exam session to database and send sync request to queue"
     (let [request (-> (mock/request :post (str routing/organizer-api-root "/1.2.3.4/exam-session") base/exam-session)
@@ -83,53 +89,46 @@
       (is (some? (:exam-session sync-req)))
       (is (= (:type sync-req) "DELETE"))))
 
+  ; '2039-05-02' no post admission
+  ; '2041-06-01' post admission, disabled
+  ; '2041-07-01' post admission, enabled
   (let [exam-session-route (str routing/organizer-api-root "/1.2.3.4/exam-session")]
-    (letfn [(mock-request [method path body] (-> (mock/request method path body)
-                                                 (mock/content-type "application/json; charset=UTF-8")
-                                                 (base/send-request-with-tx)
-                                                 (base/body-as-json)))
-            (create-es []                    (-> (mock-request :post (str exam-session-route) base/exam-session)))
-            (create-pa [exam-session-id]     (-> (mock-request :post (str exam-session-route "/" exam-session-id "/post-admission") base/post-admission)))
-            (update-pa [exam-session-id]     (-> (mock-request :post (str exam-session-route "/" exam-session-id "/post-admission") base/post-admission-updated)))
-            (activate-pa [exam-session-id]   (-> (mock-request :post (str exam-session-route "/" exam-session-id "/post-admission/activation") base/post-admission-activation)))
-            (deactivate-pa [exam-session-id] (-> (mock-request :post (str exam-session-route "/" exam-session-id "/post-admission/activation") base/post-admission-deactivation)))]
+    (letfn [(mock-request [method path body]  (-> (mock/request method path body)
+                                                  (mock/content-type "application/json; charset=UTF-8")
+                                                  (base/send-request-with-tx)))
+            (create-pa-enabled-es []          (->> (get-new-entry base/exam-session {:session_date "2041-07-01"})
+                                                   (mock-request :post (str exam-session-route))
+                                                   (base/body-as-json)))
+            (create-pa-disabled-es []         (->> (get-new-entry base/exam-session {:session_date "2041-06-01"})
+                                                   (mock-request :post (str exam-session-route))
+                                                   (base/body-as-json)))
+            (activate [exam-session-id entry] (-> (mock-request :post (str exam-session-route "/" exam-session-id "/post-admission/activate") entry)))
+            (deactivate [exam-session-id]     (-> (mock-request :post (str exam-session-route "/" exam-session-id "/post-admission/deactivate") "{}")))]
 
-      (testing "can add post admission to exam session"
-        (let [create-es-response (create-es)
-              exam-session-id    (get create-es-response "id")
-              create-pa-response (create-pa exam-session-id)]
-          (is (= {:post_admission_start_date "2039-03-02" :post_admission_quota 50 :post_admission_active false}
-                 (base/select-one (str "SELECT post_admission_start_date, post_admission_quota, post_admission_active FROM exam_session WHERE id = " exam-session-id))))))
+      (testing "can activate a exam session post admission"
+        (let [exam-session-response (create-pa-enabled-es)
+              exam-session-id (get exam-session-response "id")
+              response (activate exam-session-id (get-new-entry "{}" {:post_admission_quota 5}))
+              exam-session (base/select-one (str "SELECT * FROM exam_session WHERE id = " exam-session-id))]
+          (is (= (:status response) 200))
+          (is (= (:post_admission_active exam-session) true))
+          (is (= (:post_admission_quota exam-session) 5))))
 
-      (testing "can update existing post admission if post admission has not been activated"
-        (let [create-es-response (create-es)
-              exam-session-id    (get create-es-response "id")
-              create-pa-response (create-pa exam-session-id)
-              update-pa-response (update-pa exam-session-id)]
-          (is (= {:post_admission_start_date "2039-02-02" :post_admission_quota 10 :post_admission_active false}
-                 (base/select-one (str "SELECT post_admission_start_date, post_admission_quota, post_admission_active FROM exam_session WHERE id = " exam-session-id))))))
+      (testing "cannot activate post admission if post admissions are not enabled for that date"
+        (let [exam-session-response (create-pa-disabled-es)
+              exam-session-id (get exam-session-response "id")
+              response (activate exam-session-id (get-new-entry "{}" {:post_admission_quota 5}))
+              exam-session (base/select-one (str "SELECT * FROM exam_session WHERE id = " exam-session-id))]
+          (is (= (:status response) 409))
+          (is (= (:post_admission_active exam-session) false))
+          (is (= (:post_admission_quota exam-session) nil))))
 
-      (testing "can not update existing post admission if post admission has been activated"
-        (let [create-es-response   (create-es)
-              exam-session-id      (get create-es-response "id")
-              create-pa-response   (create-pa exam-session-id)
-              activate-pa-response (activate-pa exam-session-id)
-              update-pa-response   (update-pa exam-session-id)]
-          (is (= {"success" true} create-pa-response))
-          (is (= {:post_admission_active true}
-                 (base/select-one (str "SELECT post_admission_active FROM exam_session WHERE id = " exam-session-id))))
-          (is (= {"success" false "error" "Exam session not found"} update-pa-response))))
-
-      (testing "can update activated post admission details again after it has been deactivated"
-        (let [create-es-response     (create-es)
-              exam-session-id        (get create-es-response "id")
-              create-pa-response     (create-pa exam-session-id)
-              activate-pa-response   (activate-pa exam-session-id)
-              deactivate-pa-response (deactivate-pa exam-session-id)
-              update-pa-response     (update-pa exam-session-id)]
-          (is (= {"success" true} update-pa-response))
-          (is (= {:post_admission_start_date "2039-02-02" :post_admission_quota 10 :post_admission_active false}
-                 (base/select-one (str "SELECT post_admission_start_date, post_admission_quota, post_admission_active FROM exam_session WHERE id = " exam-session-id)))))))))
+      (testing "can disable post admissions for exam session"
+        (let [exam-session-id (:id (base/select-one (base/select-exam-session-by-date "2041-07-01")))
+              response (deactivate exam-session-id)
+              exam-session (base/select-one (str "SELECT * FROM exam_session WHERE id = " exam-session-id))]
+          (is (= (:status response) 200))
+          (is (= (:post_admission_active exam-session) false)))))))
 
 (deftest exam-session-history-test
   (base/insert-organizer "'1.2.3.4'")

--- a/test/yki/handler/post_registration_test.clj
+++ b/test/yki/handler/post_registration_test.clj
@@ -64,8 +64,8 @@
   (base/insert-payment-config "'1.2.3.5'")
   (base/insert-languages "'1.2.3.5'")
   ; both exam sessions are expected to share post admission dates for the relevant checks to work
-  (jdbc/execute! @embedded-db/conn "UPDATE exam_date SET registration_end_date = '2018-12-01', post_admission_end_date = '2039-12-31'")
-  (jdbc/execute! @embedded-db/conn "UPDATE exam_session SET post_admission_start_date = '2018-12-07', post_admission_quota = 20, post_admission_active = true WHERE id = 1")
+  (jdbc/execute! @embedded-db/conn "UPDATE exam_date SET registration_end_date = '2018-12-01', post_admission_start_date = '2018-12-07', post_admission_end_date = '2039-12-31', post_admission_enabled = true")
+  (jdbc/execute! @embedded-db/conn "UPDATE exam_session SET post_admission_quota = 20, post_admission_active = true WHERE id = 1")
   (base/insert-exam-session-with-post-admission 1 "'1.2.3.5'" 50 20)
   (base/insert-exam-session-location "'1.2.3.5'" "fi")
   (base/insert-exam-session-location "'1.2.3.5'" "sv")
@@ -89,6 +89,7 @@
                                                       :content-type "application/json"
                                                       :request-method :post))
           init-response-body     (base/body-as-json (:response init-response))
+
           _ (println "init-response-body" init-response-body)
           id                     (init-response-body "registration_id")
           create-twice-response  (-> session
@@ -104,7 +105,6 @@
                                                       :request-method :post))
           _ (println "submit-response:" (base/body-as-json (:response submit-response)))
           payment                (base/select-one (str "SELECT * FROM payment WHERE registration_id = " id))
-          exam-session           (base/select-one "SELECT * FROM exam_date WHERE id = 1")
           payment-link           (base/select-one (str "SELECT * FROM login_link WHERE registration_id = " id))
           submitted-registration (base/select-one (str "SELECT * FROM registration WHERE id = " id))
           _ (println "submitted-registration:" submitted-registration)

--- a/test/yki/handler/virkailija_auth_test.clj
+++ b/test/yki/handler/virkailija_auth_test.clj
@@ -55,11 +55,15 @@
                                                                      :url-helper url-helper
                                                                      :email-q (base/email-q)
                                                                      :data-sync-q (base/data-sync-q)})
+
+        exam-date-handler (ig/init-key :yki.handler/exam-date {:db db})
+
         org-handler (middleware/wrap-format (ig/init-key :yki.handler/organizer {:db db
                                                                                  :access-log (base/access-log)
                                                                                  :data-sync-q  (base/data-sync-q)
                                                                                  :url-helper url-helper
                                                                                  :exam-session-handler exam-session-handler
+                                                                                 :exam-date-handler exam-date-handler
                                                                                  :auth auth
                                                                                  :file-handler {}}))
         auth-handler (base/auth-handler auth url-helper)]


### PR DESCRIPTION
New organizer endpoints:
* Returning exam dates with information about organizer post admission setting
* Exam date creation
* Exam date delete
* Adding languages to exam date
* Removing languages to exam date

Other:
* Exam date language now has information about the language level
* Possibility to configure post admission settings for exam date