### PR TITLE
Run Solki participants sync job every 59 minutes for faster feedback …

### DIFF
--- a/src/yki/job/scheduled_tasks.clj
+++ b/src/yki/job/scheduled_tasks.clj
@@ -19,7 +19,7 @@
 
 (defonce participants-sync-handler-conf {:worker-id (str (UUID/randomUUID))
                                          :task "PARTICIPANTS_SYNC_HANDLER"
-                                         :interval "479 MINUTES"})
+                                         :interval "59 MINUTES"})
 
 (defonce exam-session-queue-handler-conf {:worker-id (str (UUID/randomUUID))
                                           :task "EXAM_SESSION_QUEUE_HANDLER"


### PR DESCRIPTION
…loop.