### PR TITLE
OPHYKIKEH-111: Fix email localisations

### DIFF
--- a/resources/yki/templates/payment_success.html
+++ b/resources/yki/templates/payment_success.html
@@ -38,21 +38,21 @@
 {% if contact_info.name %}
 <tr>
   <td style="padding-left: 20px;">
-    {% i18n examSession.contact.name.label %}: {{ contact_info.name }}
+    {% i18n email.payment_success.organizer_contact.name %}: {{ contact_info.name }}
   </td>
 </tr>
 {% endif %}
 {% if contact_info.email %}
 <tr>
   <td style="padding-left: 20px;">
-    {% i18n examSession.contact.email.label %}: {{ contact_info.email }}
+    {% i18n email.payment_success.organizer_contact.email %}: {{ contact_info.email }}
   </td>
 </tr>
 {% endif %}
 {% if contact_info.phone_number %}
 <tr>
   <td style="padding-left: 20px;">
-    {% i18n examSession.contact.phoneNumber.label %}: {{ contact_info.phone_number }}
+    {% i18n email.payment_success.organizer_contact.phoneNumber %}: {{ contact_info.phone_number }}
   </td>
 </tr>
 {% endif %}


### PR DESCRIPTION
Separate labels for organizer's contact information in payment-success email template.

The previous localisations were meant for clerk UI, and not suitable for customer emails.

<img width="485" alt="Screenshot 2022-12-28 at 14 21 41" src="https://user-images.githubusercontent.com/18038608/209811582-6842577c-2307-49ee-81f0-619b7c6cd93d.png">
