### PR TITLE
Fix registration state update for payments of cancelled registrations

### DIFF
--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -726,14 +726,14 @@ SET state = 'PAID',
     modified = current_timestamp
 WHERE id = :id AND state != 'PAID';
 
--- name: update-exam-registration-status-to-completed<!
+-- name: complete-registration<!
 UPDATE registration
 SET state =
     CASE WHEN state = 'SUBMITTED'::registration_state THEN 'COMPLETED'::registration_state
          ELSE 'PAID_AND_CANCELLED'::registration_state
     END,
     modified = current_timestamp
-WHERE id = :id AND state != 'COMPLETED';
+WHERE id = :id AND state IN ('SUBMITTED', 'EXPIRED', 'CANCELLED');
 
 -- name: select-payment-by-registration-id
 SELECT
@@ -933,7 +933,7 @@ AND (r.state IN ('COMPLETED', 'SUBMITTED', 'CANCELLED', 'PAID_AND_CANCELLED')
      OR (EXISTS (SELECT id from exam_payment_new WHERE registration_id = r.id)))
 ORDER BY r.created ASC;
 
---name: update-registration-status-to-cancelled!
+--name: cancel-registration!
 UPDATE registration
 SET state =
   CASE WHEN state = 'SUBMITTED'::registration_state THEN 'CANCELLED'::registration_state

--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -728,7 +728,10 @@ WHERE id = :id AND state != 'PAID';
 
 -- name: update-exam-registration-status-to-completed<!
 UPDATE registration
-SET state = 'COMPLETED',
+SET state =
+    CASE WHEN state = 'SUBMITTED'::registration_state THEN 'COMPLETED'::registration_state
+         ELSE 'PAID_AND_CANCELLED'::registration_state
+    END,
     modified = current_timestamp
 WHERE id = :id AND state != 'COMPLETED';
 
@@ -858,8 +861,6 @@ WHERE es.id = :exam_session_id
      FROM participant_sync_status pss
      WHERE pss.exam_session_id = es.id
             AND pss.success_at IS NULL)  = 0;
-
-
 
 --name: insert-relocated-participants-sync-status!
 INSERT INTO participant_sync_status(
@@ -1036,8 +1037,6 @@ ed.post_admission_enabled,
 FROM exam_date ed
 WHERE ed.exam_date >= COALESCE(:from, current_date) AND ed.deleted_at IS NULL
 ORDER BY ed.exam_date ASC;
-
-
 
 -- name: insert-exam-date<!
 INSERT INTO exam_date (

--- a/src/yki/boundary/exam_session_db.clj
+++ b/src/yki/boundary/exam_session_db.clj
@@ -124,7 +124,7 @@
   (set-registration-status-to-cancelled!
     [{:keys [spec]} registration-id oid]
     (jdbc/with-db-transaction [tx spec]
-      (int->boolean (q/update-registration-status-to-cancelled! tx {:id registration-id :oid oid}))))
+      (int->boolean (q/cancel-registration! tx {:id registration-id :oid oid}))))
   (update-exam-session!
     [{:keys [spec]} oid id exam-session]
     (jdbc/with-db-transaction [tx spec]

--- a/src/yki/boundary/registration_db.clj
+++ b/src/yki/boundary/registration_db.clj
@@ -154,7 +154,8 @@
       (rollback-on-exception
         tx
         (fn update-payment-and-registration-states! []
-          (let [updated-payment-details (q/update-new-exam-payment-to-paid<! tx {:id payment-id})]
-            (when (q/update-exam-registration-status-to-completed<! tx {:id registration-id})
-              (after-fn updated-payment-details)
-              true)))))))
+          (let [updated-payment-details (q/update-new-exam-payment-to-paid<! tx {:id payment-id})
+                updated-registration    (q/update-exam-registration-status-to-completed<! tx {:id registration-id})]
+            (when (= "COMPLETED" (:state updated-registration))
+              (after-fn updated-payment-details))
+            updated-registration))))))

--- a/src/yki/boundary/registration_db.clj
+++ b/src/yki/boundary/registration_db.clj
@@ -155,7 +155,7 @@
         tx
         (fn update-payment-and-registration-states! []
           (let [updated-payment-details (q/update-new-exam-payment-to-paid<! tx {:id payment-id})
-                updated-registration    (q/update-exam-registration-status-to-completed<! tx {:id registration-id})]
+                updated-registration    (q/complete-registration<! tx {:id registration-id})]
             (when (= "COMPLETED" (:state updated-registration))
               (after-fn updated-payment-details))
             updated-registration))))))

--- a/src/yki/handler/exam_payment_new.clj
+++ b/src/yki/handler/exam_payment_new.clj
@@ -164,19 +164,18 @@
                                                         lang
                                                         email-template-data
                                                         updated-payment-details))]
-              (let [updated-registration (registration-db/complete-new-payment-and-exam-registration! db registration-id payment-id send-registration-complete-email!)]
-                (if updated-registration
-                  (do
-                    (audit/log-participant {:request   request
-                                            :target-kv {:k audit/payment
-                                                        :v (:reference payment-details)}
-                                            :change    {:type audit/create-op
-                                                        :new  (:params request)}})
-                    (case (:state updated-registration)
-                      "COMPLETED" (log/info "Completed payment with transaction-id" transaction-id ", updating registration with id" registration-id "to COMPLETED.")
-                      "PAID_AND_CANCELLED" (log/warn "Completed payment with transaction-id" transaction-id ", updating registration with id" registration-id "to PAID_AND_CANCELLED")
-                      (log/error "Completed payment with transaction-id" transaction-id ", but unexpectedly registration with id" registration-id "is in state" (:state updated-registration))))
-                  (log/info "Success callback invoked for transaction-id" transaction-id "corresponding to already completed registration with id" registration-id "; this is a no-op.")))
+              (if-let [updated-registration (registration-db/complete-new-payment-and-exam-registration! db registration-id payment-id send-registration-complete-email!)]
+                (do
+                  (audit/log-participant {:request   request
+                                          :target-kv {:k audit/payment
+                                                      :v (:reference payment-details)}
+                                          :change    {:type audit/create-op
+                                                      :new  (:params request)}})
+                  (case (:state updated-registration)
+                    "COMPLETED" (log/info "Completed payment with transaction-id" transaction-id ", updated registration with id" registration-id "to COMPLETED.")
+                    "PAID_AND_CANCELLED" (log/warn "Completed payment with transaction-id" transaction-id ", updated registration with id" registration-id "to PAID_AND_CANCELLED")
+                    (log/error "Completed payment with transaction-id" transaction-id ", but unexpectedly registration with id" registration-id "is in state" (:state updated-registration))))
+                (log/info "Success callback invoked for transaction-id" transaction-id "corresponding to already completed registration with id" registration-id "; this is a no-op."))
               (success-redirect url-helper lang exam-session-id))
             (do
               (log/error "Success callback invoked with unexpected parameters for transaction-id" transaction-id "corresponding to registration with id" registration-id

--- a/src/yki/handler/exam_payment_new.clj
+++ b/src/yki/handler/exam_payment_new.clj
@@ -164,14 +164,19 @@
                                                         lang
                                                         email-template-data
                                                         updated-payment-details))]
-              (if (registration-db/complete-new-payment-and-exam-registration! db registration-id payment-id send-registration-complete-email!)
-                (do (audit/log-participant {:request   request
+              (let [updated-registration (registration-db/complete-new-payment-and-exam-registration! db registration-id payment-id send-registration-complete-email!)]
+                (if updated-registration
+                  (do
+                    (audit/log-participant {:request   request
                                             :target-kv {:k audit/payment
                                                         :v (:reference payment-details)}
                                             :change    {:type audit/create-op
                                                         :new  (:params request)}})
-                    (log/info "Completed payment with transaction-id" transaction-id ", updating registration with id" registration-id "to COMPLETED."))
-                (log/info "Success callback invoked for transaction-id" transaction-id "corresponding to already completed registration with id" registration-id "; this is a no-op."))
+                    (case (:state updated-registration)
+                      "COMPLETED" (log/info "Completed payment with transaction-id" transaction-id ", updating registration with id" registration-id "to COMPLETED.")
+                      "PAID_AND_CANCELLED" (log/warn "Completed payment with transaction-id" transaction-id ", updating registration with id" registration-id "to PAID_AND_CANCELLED")
+                      (log/error "Completed payment with transaction-id" transaction-id ", but unexpectedly registration with id" registration-id "is in state" (:state updated-registration))))
+                  (log/info "Success callback invoked for transaction-id" transaction-id "corresponding to already completed registration with id" registration-id "; this is a no-op.")))
               (success-redirect url-helper lang exam-session-id))
             (do
               (log/error "Success callback invoked with unexpected parameters for transaction-id" transaction-id "corresponding to registration with id" registration-id

--- a/test/yki/handler/exam_payment_new_test.clj
+++ b/test/yki/handler/exam_payment_new_test.clj
@@ -8,6 +8,7 @@
     [integrant.core :as ig]
     [muuntaja.middleware :as middleware]
     [peridot.core :as peridot]
+    [pgqueue.core :as pgq]
     [stub-http.core :refer [with-routes!]]
     [yki.boundary.registration-db :as registration-db]
     [yki.embedded-db :as embedded-db]
@@ -109,8 +110,8 @@
           with-signature       (fn [headers]
                                  (->> (sign-request {:merchant-secret "SAIPPUAKAUPPIAS"} headers nil)
                                       (assoc headers "signature")))
-          select-registration  #(base/select-one (str "SELECT * FROM registration WHERE id = " registration-id ";"))
-          select-payment       #(first (select-payments-for-registration registration-id))
+          select-registration  #(base/select-one (str "SELECT * FROM registration WHERE id = " % ";"))
+          select-payment       #(first (select-payments-for-registration %))
           request-with-headers (fn [request-headers]
                                  (success session lang request-headers))
           unauthorized?        (fn [{:keys [response]}]
@@ -120,7 +121,8 @@
                                       (re-matches #".*status=payment-error.*" (get-in response [:headers "Location"]))))
           success-redirect?    (fn [{:keys [response]}]
                                  (and (= 302 (:status response))
-                                      (str/ends-with? (get-in response [:headers "Location"]) "status=payment-success&lang=fi&id=1")))]
+                                      (str/ends-with? (get-in response [:headers "Location"]) "status=payment-success&lang=fi&id=1")))
+          take-email           (fn [] (pgq/take (base/email-q)))]
       (base/insert-exam-payment-new registration-id amount reference transaction-id href)
       (testing "Invoking success callback with missing or incorrect signature yields 401 Unauthorized"
         (is (unauthorized? (request-with-headers {})))
@@ -131,33 +133,38 @@
         (testing "When success callback is invoked with incorrect parameters, the payment and registration states remain unchanged."
           ; Only signature passed in headers -> status code 400 expected
           (is (error-redirect? (request-with-headers (with-signature {}))))
-          (is (= "SUBMITTED" (:state (select-registration))))
-          (is (= "UNPAID" (:state (select-payment))))
+          (is (= "SUBMITTED" (:state (select-registration registration-id))))
+          (is (= "UNPAID" (:state (select-payment registration-id))))
+          (is (nil? (take-email)))
           ; Mismatching amount -> error
           (is (error-redirect? (->> (update correct-headers "checkout-amount" inc)
                                     (with-signature)
                                     (request-with-headers))))
-          (is (= "SUBMITTED" (:state (select-registration))))
-          (is (= "UNPAID" (:state (select-payment))))
+          (is (= "SUBMITTED" (:state (select-registration registration-id))))
+          (is (= "UNPAID" (:state (select-payment registration-id))))
+          (is (nil? (take-email)))
           ; Mismatching transaction-id -> error
           (is (error-redirect? (->> (assoc correct-headers "checkout-transaction-id" inc)
                                     (with-signature)
                                     (request-with-headers))))
-          (is (= "SUBMITTED" (:state (select-registration))))
-          (is (= "UNPAID" (:state (select-payment))))
+          (is (= "SUBMITTED" (:state (select-registration registration-id))))
+          (is (= "UNPAID" (:state (select-payment registration-id))))
+          (is (nil? (take-email)))
           ; Mismatching status -> error
           (is (error-redirect? (->> (assoc correct-headers "checkout-status" "error")
                                     (with-signature)
                                     (request-with-headers))))
-          (is (= "SUBMITTED" (:state (select-registration))))
-          (is (= "UNPAID" (:state (select-payment)))))
+          (is (= "SUBMITTED" (:state (select-registration registration-id))))
+          (is (= "UNPAID" (:state (select-payment registration-id))))
+          (is (nil? (take-email))))
 
         (testing "Payment and registration status are updated when callback is invoked with correct parameters"
           (is (success-redirect? (->> correct-headers
                                       (with-signature)
                                       (request-with-headers))))
-          (is (= "COMPLETED" (:state (select-registration))))
-          (is (= "PAID" (:state (select-payment)))))
+          (is (= "COMPLETED" (:state (select-registration registration-id))))
+          (is (= "PAID" (:state (select-payment registration-id))))
+          (is (take-email)))
 
         (testing "Further calls to success callback do not change payment or registration status"
           ; Endpoint called with unexpected value for checkout-status header
@@ -165,15 +172,34 @@
           (is (error-redirect? (->> (assoc correct-headers "checkout-status" "error")
                                     (with-signature)
                                     (request-with-headers))))
-          (is (= "COMPLETED" (:state (select-registration))))
-          (is (= "PAID" (:state (select-payment)))))
-        ; Endpoint called again with correct parameters
-        ; => redirect, registration and payment status remain unchanged
-        (is (success-redirect? (->> correct-headers
-                                    (with-signature)
-                                    (request-with-headers))))
-        (is (= "COMPLETED" (:state (select-registration))))
-        (is (= "PAID" (:state (select-payment))))))))
+          (is (= "COMPLETED" (:state (select-registration registration-id))))
+          (is (= "PAID" (:state (select-payment registration-id))))
+          (is (nil? (take-email)))
+          ; Endpoint called again with correct parameters
+          ; => redirect, registration and payment status remain unchanged
+          (is (success-redirect? (->> correct-headers
+                                      (with-signature)
+                                      (request-with-headers))))
+          (is (= "COMPLETED" (:state (select-registration registration-id))))
+          (is (= "PAID" (:state (select-payment registration-id))))
+          (is (nil? (take-email))))
+
+        (testing "Completing payment for a CANCELLED registration updates it to PAID_AND_CANCELLED"
+          (base/insert-registrations "CANCELLED")
+          (let [cancelled-registration-id 4
+                new-reference             (str reference "-2")
+                new-transaction-id        (str transaction-id "-2")
+                correct-headers           {"checkout-amount"         amount
+                                           "checkout-transaction-id" new-transaction-id
+                                           "checkout-status"         "ok"}
+                new-href                  (str "https://pay.paytrail.com/pay/" new-transaction-id)]
+            (base/insert-exam-payment-new cancelled-registration-id amount new-reference new-transaction-id new-href)
+            (is (success-redirect? (->> correct-headers
+                                        (with-signature)
+                                        (request-with-headers))))
+            (is (= "PAID_AND_CANCELLED" (:state (select-registration cancelled-registration-id))))
+            (is (= "PAID" (:state (select-payment cancelled-registration-id))))
+            (is (nil? (take-email)))))))))
 
 (deftest paytrail-payment-contents-test
   (with-routes!


### PR DESCRIPTION
If payment for CANCELLED registration is completed, update state to PAID_AND_CANCELLED.

Add also test coverage and ensure payment success email is sent exactly when registration status changes to COMPLETED for the first time.