### PR TITLE
Koetilaisuuksien synkronointi SOLKIin tunneittain

### DIFF
--- a/resources/yki/config.edn
+++ b/resources/yki/config.edn
@@ -80,7 +80,7 @@
   :duct.scheduler/simple
   {:thread-pool-size 10
    :jobs             [{:interval 60 :delay 60 :run #ig/ref :yki.job.scheduled-tasks/registration-state-handler}
-                      {:interval 28800 :delay 60 :run #ig/ref :yki.job.scheduled-tasks/participants-sync-handler}
+                      {:interval 3600 :delay 60 :run #ig/ref :yki.job.scheduled-tasks/participants-sync-handler}
                       {:interval 1 :delay 60 :run #ig/ref :yki.job.scheduled-tasks/email-queue-reader}
                       {:interval 60 :delay 60 :run #ig/ref :yki.job.scheduled-tasks/data-sync-queue-reader}
                       {:interval 600 :delay 60 :run #ig/ref :yki.job.scheduled-tasks/exam-session-queue-handler}]}

--- a/src/yki/job/scheduled_tasks.clj
+++ b/src/yki/job/scheduled_tasks.clj
@@ -66,8 +66,8 @@
   #(try
      (when (job-db/try-to-acquire-lock! db participants-sync-handler-conf)
        (log/info "Check participants sync")
-       (let [exam-sessions (exam-session-db/get-exam-sessions-to-be-synced db (str retry-duration-in-days " days"))]
-         (log/info "Syncronizing participants of exam sessions" exam-sessions)
+       (when-let [exam-sessions (seq (exam-session-db/get-exam-sessions-to-be-synced db (str retry-duration-in-days " days")))]
+         (log/info "Syncronizing participants of exam sessions" (map :exam_session_id exam-sessions))
          (doseq [exam-session exam-sessions]
            (try
              (yki-register/sync-exam-session-participants db url-helper basic-auth disabled (:exam_session_id exam-session))


### PR DESCRIPTION
PR:ssä https://github.com/Opetushallitus/yki/pull/164 yritetty aiemmin muuttaa tietojen synkronoinnin aikaväliä 8h -> 1h, mutta muutos oikeasti vaikutti vain siihen kuinka kauan task_lock-taulussa määritelty tausta-ajon lukko oli voimassa. 

Tässä PR:ssä oikeasti muutetaan skeduloinnin frekvenssiä ja lisäksi siistitään hieman lokitusta.