### PR TITLE
Korjaus ilmoittautumisten erääntymiseen

### DIFF
--- a/src/yki/boundary/registration_db.clj
+++ b/src/yki/boundary/registration_db.clj
@@ -120,9 +120,7 @@
   (update-submitted-registrations-to-expired!
     [{:keys [spec]}]
     (jdbc/with-db-transaction [tx spec]
-      (let [ids-from-expired-legacy-payments (q/update-submitted-registrations-with-unpaid-legacy-payments-to-expired<! tx)
-            ids-from-new-payments            (q/update-submitted-registrations-without-paid-new-payments-to-expired<! tx)]
-        (concat ids-from-expired-legacy-payments ids-from-new-payments))))
+      (q/update-submitted-registrations-to-expired<! tx)))
   (get-participant-data-by-order-number
     [{:keys [spec]} order-number]
     (first (q/select-participant-data-by-order-number spec {:order_number order-number})))


### PR DESCRIPTION
Cherry-pickattu PR:stä https://github.com/Opetushallitus/yki/pull/181

Fix payment expiration logic: if registration wasn't marked as COMPLETED 8 days from its creation, it will be expired.

No need to examine the details of its payment at this point; if any payment related to it was paid, the registration itself would also have been marked COMPLETED.