### PR TITLE
Filter out registrations without submitted form details from exam participants response.

### DIFF
--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -963,6 +963,7 @@ INNER JOIN registration r ON es.id = r.exam_session_id
 WHERE es.id = :id
 AND es.organizer_id IN (SELECT id FROM organizer WHERE oid = :oid)
 AND r.state != 'STARTED'
+AND r.form IS NOT NULL
 ORDER BY r.created ASC;
 
 --name: cancel-registration-for-organizer!

--- a/src/yki/spec.clj
+++ b/src/yki/spec.clj
@@ -276,8 +276,6 @@
                                  ::nationalities
                                  ::certificate_lang
                                  ::exam_lang
-                                 ; TODO FIXME Should be s/or instead or some other refactoring?
-                                 ;  Currently returns always just ::birthdate.
                                  (or ::birthdate ::ssn)
                                  ::post_office
                                  ::zip


### PR DESCRIPTION
Fixes cases where response fails spec due to form being null.