### PR TITLE
OPHYKIKEH-207: Mahdollisten osallistumiskieltojen haku myös hetun perusteella

### DIFF
--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -176,7 +176,8 @@ INNER JOIN registration r
       -- Form may not contain birthdate in which case we need to
       -- compare the date part of ssn with birthdate registered for quarantine.
       -- We achieve that by converting q.birthdate into a regex of suitable form.
-      r.form->>'ssn' LIKE to_char(to_date(q.birthdate, 'YYYY-MM-DD'), 'DDMMYY%'))
+      (r.form->>'birthdate' IS NULL AND
+       r.form->>'ssn' LIKE to_char(to_date(q.birthdate, 'YYYY-MM-DD'), 'DDMMYY%')))
 INNER JOIN exam_session es
   ON r.exam_session_id = es.id
 INNER JOIN exam_date ed

--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -171,7 +171,12 @@ SELECT
   es.language_code
 FROM quarantine q
 INNER JOIN registration r
-  ON q.birthdate = r.form->>'birthdate'
+  ON (q.birthdate = r.form->>'birthdate'
+      OR
+      -- Form may not contain birthdate in which case we need to
+      -- compare the date part of ssn with birthdate registered for quarantine.
+      -- We achieve that by converting q.birthdate into a regex of suitable form.
+      r.form->>'ssn' LIKE to_char(to_date(q.birthdate, 'YYYY-MM-DD'), 'DDMMYY%'))
 INNER JOIN exam_session es
   ON r.exam_session_id = es.id
 INNER JOIN exam_date ed

--- a/test/yki/handler/base_test.clj
+++ b/test/yki/handler/base_test.clj
@@ -211,8 +211,9 @@
   (jdbc/execute! @embedded-db/conn (str "UPDATE exam_date SET exam_date='" new-exam-date "' WHERE id=" exam-date-id ";")))
 
 (defn update-registration-form! [registration-id attr val]
-  {:pre [(pos-int? registration-id) (string? attr) (string? val)]}
-  (jdbc/execute! @embedded-db/conn (str "UPDATE registration SET form = JSONB_SET(form, '{" attr "}', '\"" val "\"') WHERE id=" registration-id ";")))
+  {:pre [(pos-int? registration-id) (string? attr) (or (string? val)
+                                                       (nil? val))]}
+  (jdbc/execute! @embedded-db/conn (str "UPDATE registration SET form = JSONB_SET(form, '{" attr "}', '" (if val (str "\"" val "\"") "null") "') WHERE id=" registration-id ";")))
 
 (defn update-registration-state! [registration-id state]
   (jdbc/execute! @embedded-db/conn (str "UPDATE registration SET state='" state "' WHERE id=" registration-id ";")))

--- a/test/yki/handler/quarantine_test.clj
+++ b/test/yki/handler/quarantine_test.clj
@@ -85,6 +85,7 @@
                      (count))
                  1))))
       (testing "one quarantine can produce multiple matches and ssn on registration form can be matched against quarantine birthdate as well"
+        (base/update-registration-form! 2 "birthdate" nil)
         (base/update-registration-form! 2 "ssn" "270199-999C")
         (is (= (-> (get-matches)
                    (count))

--- a/test/yki/handler/quarantine_test.clj
+++ b/test/yki/handler/quarantine_test.clj
@@ -84,8 +84,8 @@
           (is (= (-> (get-matches)
                      (count))
                  1))))
-      (testing "one quarantine can produce multiple matches"
-        (base/update-registration-form! 2 "birthdate" (:birthdate base/quarantine-form))
+      (testing "one quarantine can produce multiple matches and ssn on registration form can be matched against quarantine birthdate as well"
+        (base/update-registration-form! 2 "ssn" "270199-999C")
         (is (= (-> (get-matches)
                    (count))
                2)))


### PR DESCRIPTION
Toteutettu tällä hetkellä muokkaamalla `select-quarantine-matches`-kyselyä. 

Vaihtoehtoisesti tämä voitaisiin myös toteuttaa ilmoittautumisvaiheessa tallentamalla kantaan ilmolomakkeen hetusta päätelty syntymäaika. Tämä vaihtoehtoinen ratkaisu olisi oletettavasti kyselyvaiheen kannalta parempi. Toisaalta myös pysyvämpi, niin hyvässä kuin pahassa.