### PR TITLE
OPHYKIKEH-207 / Syntymäajan päättely ja tallennus hetun perusteella

### DIFF
--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -176,7 +176,8 @@ INNER JOIN registration r
       -- Form may not contain birthdate in which case we need to
       -- compare the date part of ssn with birthdate registered for quarantine.
       -- We achieve that by converting q.birthdate into a regex of suitable form.
-      r.form->>'ssn' LIKE to_char(to_date(q.birthdate, 'YYYY-MM-DD'), 'DDMMYY%'))
+      (r.form->>'birthdate' IS NULL AND
+       r.form->>'ssn' LIKE to_char(to_date(q.birthdate, 'YYYY-MM-DD'), 'DDMMYY%')))
 INNER JOIN exam_session es
   ON r.exam_session_id = es.id
 INNER JOIN exam_date ed

--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -171,7 +171,12 @@ SELECT
   es.language_code
 FROM quarantine q
 INNER JOIN registration r
-  ON q.birthdate = r.form->>'birthdate'
+  ON (q.birthdate = r.form->>'birthdate'
+      OR
+      -- Form may not contain birthdate in which case we need to
+      -- compare the date part of ssn with birthdate registered for quarantine.
+      -- We achieve that by converting q.birthdate into a regex of suitable form.
+      r.form->>'ssn' LIKE to_char(to_date(q.birthdate, 'YYYY-MM-DD'), 'DDMMYY%'))
 INNER JOIN exam_session es
   ON r.exam_session_id = es.id
 INNER JOIN exam_date ed

--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -173,6 +173,11 @@ FROM quarantine q
 INNER JOIN registration r
   ON (q.birthdate = r.form->>'birthdate'
       OR
+      -- TODO Remove this OR branch once all registrations to be inspected
+      -- are guaranteed to have birthdates - probably after summer 2023, as
+      -- it is expected that some participation bans are submitted (and handled)
+      -- then.
+      --
       -- Form may not contain birthdate in which case we need to
       -- compare the date part of ssn with birthdate registered for quarantine.
       -- We achieve that by converting q.birthdate into a regex of suitable form.

--- a/src/yki/boundary/quarantine_db.clj
+++ b/src/yki/boundary/quarantine_db.clj
@@ -27,7 +27,7 @@
 (defn- with-placeholders-for-optional-values [quarantine]
   (merge {:ssn nil :phone_number nil :email nil} quarantine))
 
-(defn with-birthdate-in-form [quarantine-match]
+(defn- with-birthdate-in-form [quarantine-match]
   (update quarantine-match :form
           (fn [{:keys [birthdate ssn] :as form}]
             (if birthdate

--- a/src/yki/boundary/quarantine_db.clj
+++ b/src/yki/boundary/quarantine_db.clj
@@ -5,6 +5,8 @@
             [duct.database.sql]
             [jeesql.core :refer [require-sql]]
             [yki.boundary.db-extensions]
+            [yki.spec :refer [ssn->date]]
+            [yki.util.common :refer [format-date-for-db]]
             [yki.util.db :refer [rollback-on-exception]])
   (:import [duct.database.sql Boundary]))
 
@@ -24,6 +26,15 @@
 
 (defn- with-placeholders-for-optional-values [quarantine]
   (merge {:ssn nil :phone_number nil :email nil} quarantine))
+
+(defn with-birthdate-in-form [quarantine-match]
+  (update quarantine-match :form
+          (fn [{:keys [birthdate ssn] :as form}]
+            (if birthdate
+              form
+              (assoc form :birthdate (-> ssn
+                                         ssn->date
+                                         format-date-for-db))))))
 
 (defprotocol Quarantine
   (create-quarantine! [db quarantine])
@@ -60,6 +71,7 @@
     (first (q/select-quarantine spec {:id id})))
   (get-quarantine-matches [{:keys [spec]}]
     (->> (q/select-quarantine-matches spec)
+         (map with-birthdate-in-form)
          (map without-nils)))
   (set-registration-quarantine! [{:keys [spec]} quarantine-id registration-id quarantined reviewer-oid]
     (jdbc/with-db-transaction [tx spec]
@@ -74,4 +86,5 @@
                                              :reviewer_oid    reviewer-oid})))))
   (get-reviews [{:keys [spec]}]
     (->> (q/select-quarantine-reviews spec)
+         (map with-birthdate-in-form)
          (map without-nils))))

--- a/src/yki/registration/registration.clj
+++ b/src/yki/registration/registration.clj
@@ -136,7 +136,10 @@
 (defn with-birthdate [form]
   (if (:birthdate form)
     form
-    (assoc form :birthdate (ssn->date (:ssn form)))))
+    (assoc form :birthdate (some-> form
+                                   :ssn
+                                   ssn->date
+                                   common/format-date-for-db))))
 
 (defn submit-registration-abstract-flow
   [db url-helper payment-helper email-q lang session registration-id raw-form onr-client exam-session-registration use-yki-ui?]

--- a/src/yki/registration/registration.clj
+++ b/src/yki/registration/registration.clj
@@ -142,9 +142,9 @@
   [db url-helper payment-helper email-q lang session registration-id raw-form onr-client exam-session-registration use-yki-ui?]
   (let [form                   (sanitized-form raw-form)
         identity               (:identity session)
-        form-to-persist        (-> form
-                                   (with-session-details session)
-                                   (with-birthdate))
+        form-to-persist        (->> form
+                                    (with-session-details session)
+                                    (with-birthdate))
         session-participant-id (get-participant-id db identity)
         email                  (:email form)
         started?               (= (:state exam-session-registration) "STARTED")]

--- a/src/yki/registration/registration.clj
+++ b/src/yki/registration/registration.clj
@@ -128,7 +128,7 @@
       ongoing-registration-expiration
       registration-end-date)))
 
-(defn- with-session-details [{:keys [auth-method identity]} form]
+(defn- with-session-details [form {:keys [auth-method identity]}]
   (if (= auth-method "EMAIL")
     (assoc form :email (:external-user-id identity))
     (assoc form :ssn (:ssn identity))))
@@ -145,9 +145,9 @@
   [db url-helper payment-helper email-q lang session registration-id raw-form onr-client exam-session-registration use-yki-ui?]
   (let [form                   (sanitized-form raw-form)
         identity               (:identity session)
-        form-to-persist        (->> form
-                                    (with-session-details session)
-                                    (with-birthdate))
+        form-to-persist        (-> form
+                                   (with-session-details session)
+                                   (with-birthdate))
         session-participant-id (get-participant-id db identity)
         email                  (:email form)
         started?               (= (:state exam-session-registration) "STARTED")]

--- a/src/yki/registration/registration.clj
+++ b/src/yki/registration/registration.clj
@@ -128,12 +128,12 @@
       ongoing-registration-expiration
       registration-end-date)))
 
-(defn with-session-details [{:keys [auth-method identity]} form]
+(defn- with-session-details [{:keys [auth-method identity]} form]
   (if (= auth-method "EMAIL")
     (assoc form :email (:external-user-id identity))
     (assoc form :ssn (:ssn identity))))
 
-(defn with-birthdate [form]
+(defn- with-birthdate [form]
   (if (:birthdate form)
     form
     (assoc form :birthdate (some-> form

--- a/src/yki/util/common.clj
+++ b/src/yki/util/common.clj
@@ -45,5 +45,3 @@
 
 (defn format-date-for-db [date]
   (f/unparse (f/formatter date-format) date))
-
-(format-datetime-for-export (t/now))

--- a/src/yki/util/common.clj
+++ b/src/yki/util/common.clj
@@ -42,3 +42,8 @@
 
 (defn format-datetime-for-export [datetime]
   (f/unparse export-datetime-formatter datetime))
+
+(defn format-date-for-db [date]
+  (f/unparse (f/formatter date-format) date))
+
+(format-datetime-for-export (t/now))

--- a/test/yki/handler/base_test.clj
+++ b/test/yki/handler/base_test.clj
@@ -214,8 +214,9 @@
   (jdbc/execute! @embedded-db/conn (str "UPDATE exam_date SET exam_date='" new-exam-date "' WHERE id=" exam-date-id ";")))
 
 (defn update-registration-form! [registration-id attr val]
-  {:pre [(pos-int? registration-id) (string? attr) (string? val)]}
-  (jdbc/execute! @embedded-db/conn (str "UPDATE registration SET form = JSONB_SET(form, '{" attr "}', '\"" val "\"') WHERE id=" registration-id ";")))
+  {:pre [(pos-int? registration-id) (string? attr) (or (string? val)
+                                                       (nil? val))]}
+  (jdbc/execute! @embedded-db/conn (str "UPDATE registration SET form = JSONB_SET(form, '{" attr "}', '" (if val (str "\"" val "\"") "null") "') WHERE id=" registration-id ";")))
 
 (defn update-registration-state! [registration-id state]
   (jdbc/execute! @embedded-db/conn (str "UPDATE registration SET state='" state "' WHERE id=" registration-id ";")))

--- a/test/yki/handler/quarantine_test.clj
+++ b/test/yki/handler/quarantine_test.clj
@@ -85,6 +85,7 @@
                      (count))
                  1))))
       (testing "one quarantine can produce multiple matches and ssn on registration form can be matched against quarantine birthdate as well"
+        (base/update-registration-form! 2 "birthdate" nil)
         (base/update-registration-form! 2 "ssn" "270199-999C")
         (is (= (-> (get-matches)
                    (count))

--- a/test/yki/handler/quarantine_test.clj
+++ b/test/yki/handler/quarantine_test.clj
@@ -89,7 +89,11 @@
         (base/update-registration-form! 2 "ssn" "270199-999C")
         (is (= (-> (get-matches)
                    (count))
-               2)))
+               2))
+        (testing "missing birthdate on registration form is replaced by value converted from SSN"
+          (is (= ["1999-01-27" "1999-01-27"]
+                 (->> (get-matches)
+                      (map (comp :birthdate :form)))))))
       (testing "multiple quarantines can match same registration"
         (base/insert-quarantine (-> base/quarantine-form
                                     (dissoc :ssn)
@@ -172,8 +176,8 @@
                                                          {:is_quarantined quarantined?}))
           select-quarantine-details-for-registration #(base/select-one
                                                         (str "SELECT r.id, r.state, qr.quarantine_id, qr.quarantined FROM registration r INNER JOIN quarantine_review qr ON r.id = qr.registration_id WHERE r.id = " % ";"))
-          update-registration-exam-date! (fn [registration-id new-exam-date]
-                                          (base/execute! (str "UPDATE exam_date SET exam_date='" new-exam-date "' WHERE id IN (SELECT ed.id FROM exam_date ed INNER JOIN exam_session es ON ed.id = es.exam_date_id INNER JOIN registration r ON es.id = r.exam_session_id WHERE r.id=" registration-id ");")))]
+          update-registration-exam-date!             (fn [registration-id new-exam-date]
+                                                       (base/execute! (str "UPDATE exam_date SET exam_date='" new-exam-date "' WHERE id IN (SELECT ed.id FROM exam_date ed INNER JOIN exam_session es ON ed.id = es.exam_date_id INNER JOIN registration r ON es.id = r.exam_session_id WHERE r.id=" registration-id ");")))]
       (testing "set quarantine endpoint should return 200"
         (testing "confirming a quarantine must not cancel registration if the exam date is in the past"
           (is (= {:body   {:success true}

--- a/test/yki/handler/quarantine_test.clj
+++ b/test/yki/handler/quarantine_test.clj
@@ -84,8 +84,8 @@
           (is (= (-> (get-matches)
                      (count))
                  1))))
-      (testing "one quarantine can produce multiple matches"
-        (base/update-registration-form! 2 "birthdate" (:birthdate base/quarantine-form))
+      (testing "one quarantine can produce multiple matches and ssn on registration form can be matched against quarantine birthdate as well"
+        (base/update-registration-form! 2 "ssn" "270199-999C")
         (is (= (-> (get-matches)
                    (count))
                2)))

--- a/test/yki/handler/registration_commons.clj
+++ b/test/yki/handler/registration_commons.clj
@@ -42,21 +42,7 @@
    :birthdate        "1999-01-01"
    :certificate_lang "fi"
    :exam_lang        "fi"
-   :post_office      "Helsinki;"
-   :zip              "01000"
-   :street_address   "Ateläniitynpolku 29 G"
-   :phone_number     "04012345"
-   :email            "test@test.com"})
-
-(def registration-form-with-ssn
-  {:first_name       "Fuu"
-   :last_name        "Bar"
-   :gender           "1"
-   :nationalities    []
-   :ssn              "010170-999R"
-   :certificate_lang "fi"
-   :exam_lang        "fi"
-   :post_office      "Helsinki;"
+   :post_office      "Helsinki"
    :zip              "01000"
    :street_address   "Ateläniitynpolku 29 G"
    :phone_number     "04012345"

--- a/test/yki/handler/registration_commons.clj
+++ b/test/yki/handler/registration_commons.clj
@@ -42,7 +42,7 @@
    :birthdate        "1999-01-01"
    :certificate_lang "fi"
    :exam_lang        "fi"
-   :post_office      "Helsinki"
+   :post_office      "Helsinki;"
    :zip              "01000"
    :street_address   "Ateläniitynpolku 29 G"
    :phone_number     "04012345"

--- a/test/yki/handler/registration_commons.clj
+++ b/test/yki/handler/registration_commons.clj
@@ -48,6 +48,20 @@
    :phone_number     "04012345"
    :email            "test@test.com"})
 
+(def registration-form-with-ssn
+  {:first_name       "Fuu"
+   :last_name        "Bar"
+   :gender           "1"
+   :nationalities    []
+   :ssn              "010170-999R"
+   :certificate_lang "fi"
+   :exam_lang        "fi"
+   :post_office      "Helsinki;"
+   :zip              "01000"
+   :street_address   "Ateläniitynpolku 29 G"
+   :phone_number     "04012345"
+   :email            "test@test.com"})
+
 (defn insert-common-base-data [organizer-oid]
   (base/insert-base-data)
   (base/insert-organizer organizer-oid)
@@ -75,26 +89,27 @@
                                                     :content-type "application/json"
                                                     :request-method :post))
         registration           (base/select-one (str "SELECT * FROM registration WHERE id = " registration-id))
-        submit-response        (-> session
-                                   (peridot/request (str routing/registration-api-root "/" registration-id "/submit" "?lang=fi")
-                                                    :body (j/write-value-as-string registration-form-data)
-                                                    :content-type "application/json"
-                                                    :request-method :post))
-        payment                (base/select-one (str "SELECT * FROM exam_payment_new WHERE registration_id = " registration-id))
-        payment-link           (base/select-one (str "SELECT * FROM login_link WHERE registration_id = " registration-id))
-        submitted-registration (base/select-one (str "SELECT * FROM registration WHERE id = " registration-id))
-        email-request          (pgq/take email-q)]
-    {:session                session
-     :init-response          init-response
-     :init-response-body     init-response-body
-     :registration           registration
-     :registration-id        registration-id
-     :create-twice-response  create-twice-response
-     :submit-response        submit-response
-     :payment                payment
-     :payment-link           payment-link
-     :submitted-registration submitted-registration
-     :email-request          email-request}))
+        submit-form!           (fn [form]
+                                 (-> session
+                                     (peridot/request (str routing/registration-api-root "/" registration-id "/submit" "?lang=fi")
+                                                      :body (j/write-value-as-string form)
+                                                      :content-type "application/json"
+                                                      :request-method :post)))
+        get-payment                #(base/select-one (str "SELECT * FROM exam_payment_new WHERE registration_id = " registration-id))
+        get-payment-link           #(base/select-one (str "SELECT * FROM login_link WHERE registration_id = " registration-id))
+        get-submitted-registration #(base/select-one (str "SELECT * FROM registration WHERE id = " registration-id))
+        get-email-request          #(pgq/take email-q)]
+    {:session                    session
+     :init-response              init-response
+     :init-response-body         init-response-body
+     :registration               registration
+     :registration-id            registration-id
+     :create-twice-response      create-twice-response
+     :submit-form!               submit-form!
+     :get-payment                get-payment
+     :get-payment-link           get-payment-link
+     :get-submitted-registration get-submitted-registration
+     :get-email-request          get-email-request}))
 
 (defn registration-success-redirect [registration-id port]
   (str "http://yki.localhost:"

--- a/test/yki/handler/registration_test.clj
+++ b/test/yki/handler/registration_test.clj
@@ -13,7 +13,6 @@
                                                       fill-exam-session
                                                       insert-common-base-data
                                                       registration-form-data
-                                                      registration-form-with-ssn
                                                       registration-success-redirect]]
             [yki.handler.routing :as routing]))
 
@@ -120,9 +119,9 @@
           ssn                "010170-999R"
           inferred-birthdate "1970-01-01"]
       (testing "submitting form with SSN but no birthdate should result in birthdate inferred from SSN"
-        (is (= ssn (:ssn registration-form-with-ssn)))
-        (is (= nil (:birthdate registration-form-with-ssn)))
-        (submit-form! registration-form-with-ssn)
+        (submit-form! (-> registration-form-data
+                          (dissoc :birthdate)
+                          (assoc :ssn ssn)))
         (let [submitted-registration (get-submitted-registration)]
           (is (= ssn (get-in submitted-registration [:form :ssn])))
           (is (= inferred-birthdate (get-in submitted-registration [:form :birthdate]))))))))


### PR DESCRIPTION
Vaihtoehtoinen toteutus jossa korjattu ongelma muokkaamalla queryä löytyy PR:stä #209. Tässä etuna että query pysyy siistimpänä, mutta jokseenkin "invasiivisempi" toteutus koska muokataan käyttäjän syöttämää dataa.