### PR TITLE
OPHYKIKEH-230: Fix logging of expired registration ids.

### DIFF
--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -680,7 +680,7 @@ WHERE state = 'SUBMITTED'
 UPDATE registration
 SET state = 'EXPIRED',
     modified = current_timestamp
-WHERE id IN (:ids);
+WHERE id IN (:ids) AND state IN ('STARTED', 'SUBMITTED');
 
 -- name: update-registration-exam-session!
 UPDATE registration

--- a/src/yki/boundary/registration_db.clj
+++ b/src/yki/boundary/registration_db.clj
@@ -89,11 +89,19 @@
   (update-started-registrations-to-expired!
     [{:keys [spec]}]
     (jdbc/with-db-transaction [tx spec]
-      (q/update-started-registrations-to-expired<! tx)))
+      (let [ids (->> (q/select-started-registrations-to-expire tx)
+                     (map :id))]
+        (when (seq ids)
+          (q/expire-registrations-by-ids! tx {:ids ids})
+          ids))))
   (update-submitted-registrations-to-expired!
     [{:keys [spec]}]
     (jdbc/with-db-transaction [tx spec]
-      (q/update-submitted-registrations-to-expired<! tx)))
+      (let [ids (->> (q/select-submitted-registrations-to-expire tx)
+                     (map :id))]
+        (when (seq ids)
+          (q/expire-registrations-by-ids! tx {:ids ids})
+          ids))))
   (get-participant-data-by-registration-id
     [{:keys [spec]} registration-id]
     (first (q/select-participant-data-by-registration-id spec {:id registration-id})))

--- a/src/yki/job/scheduled_tasks.clj
+++ b/src/yki/job/scheduled_tasks.clj
@@ -52,11 +52,11 @@
   #(try
      (when (job-db/try-to-acquire-lock! db registration-state-handler-conf)
        (log/debug "Check started registrations expiry")
-       (let [updated (registration-db/update-started-registrations-to-expired! db)]
-         (when updated (log/info "Started registrations set to expired" updated)))
+       (let [ids (registration-db/update-started-registrations-to-expired! db)]
+         (when ids (log/info "Started registrations set to expired" ids)))
        (log/debug "Check submitted registrations expiry")
-       (let [updated (registration-db/update-submitted-registrations-to-expired! db)]
-         (when updated (log/info "Submitted registrations set to expired" updated))))
+       (let [ids (registration-db/update-submitted-registrations-to-expired! db)]
+         (when ids (log/info "Submitted registrations set to expired" ids))))
      (catch Exception e
        (log/error e "Registration state handler failed"))))
 


### PR DESCRIPTION
Despite best intentions, the previous implementation with 'UPDATE ... RETURNING id AS updated' only ever wanted to return one of potentially many updated row ids.
Trying to coerce the jeesql / clojure.data.jdbc / the JDBC driver itself to instead return all ids proved unsuccessful, hence this roundabout way of first looking up ids, then updating rows with matching ids, then returning the ids looked up.