### PR TITLE
Fixup: support endpoint /auth/user while it's still used by the legacy frontend

### DIFF
--- a/src/yki/handler/auth.clj
+++ b/src/yki/handler/auth.clj
@@ -17,6 +17,10 @@
       :coercion :spec
       :no-doc true
       :middleware [auth access-log wrap-params]
+      ; TODO Duplicates functionality provided by endpoint /yki/api/user/identity
+      ; Used by legacy yki-frontend. Remove once yki-frontend no longer uses this endpoint.
+      (GET "/user" {session :session}
+        (ok (update-in session [:identity] dissoc :ticket)))
       (GET "/login" [code lang]
         (code-auth/login db code lang url-helper))
       (GET "/logout" {session :session}

--- a/src/yki/middleware/auth.clj
+++ b/src/yki/middleware/auth.clj
@@ -116,6 +116,8 @@
     :handler any-access}
    {:pattern #".*/auth/initsession"
     :handler any-access}
+   {:pattern #".*/auth/user"
+    :handler any-access}
    {:pattern #".*/auth/callback"
     :handler any-access}
    {:pattern        #".*/auth/callback.*"


### PR DESCRIPTION
Testattu untuvalla toimivaksi. Virhetilanteessa virkailija-UI jäi retry-loopiin yrittäessään hakea käyttäjän tietoja `/auth/user`-endpointista.