### PR TITLE
Use patched version of clj-json-patch.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,7 @@
                  [fi.vm.sade/auditlogger "9.2.4-SNAPSHOT"]
                  [fi.vm.sade.java-utils/java-properties "0.1.0-SNAPSHOT"]
                  [com.github.jhonnymertz/java-wkhtmltopdf-wrapper "1.1.14-RELEASE"]
-                 [clj-json-patch "0.1.7"]]
+                 [org.clojars.pkoivisto/clj-json-patch "0.1.9"]]
   :exclusions [org.slf4j/slf4j-nop
                commons-logging]
   :cloverage {:ns-exclude-regex [#"dev" #"user" #"yki.main" #"yki.middleware.no-auth" #"yki.migrations"]}


### PR DESCRIPTION
Should fix the following error found on pallero-app-yki logs:
```
[qtp1364544938-76] ERROR yki.util.log-util: Post-processing patch array failed. Returning instead original patch array for audit logging:  [{op replace, path /languages/4/language_code, value swe} {op replace, path /languages/4/level_code, value YLIN} {op replace, path /languages/5, value {level_code PERUS, language_code spa}} {op add, path /languages/6, value {level_code YLIN, language_code spa}}]
```