### PR TITLE
OPHKIOS-69: Korjaus tutkintotilaisuuden poistamisen virhetilanteeseen

### DIFF
--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -992,6 +992,10 @@ UPDATE participant_sync_status
 SET failed_at = current_timestamp
 WHERE exam_session_id = :exam_session_id;
 
+-- name: delete-participant-sync-status!
+DELETE FROM participant_sync_status
+WHERE exam_session_id = :exam_session_id;
+
 -- name: select-completed-exam-session-participants
 SELECT form, person_oid
 FROM registration


### PR DESCRIPTION
Korjataan lokeilta huomattu seuraavanlainen virhe tutkintotilaisuuden poistoa yrittäessä:
```
Caused by: org.postgresql.util.PSQLException: ERROR: update or delete on table "exam_session" violates foreign key constraint "participant_sync_status_exam_session_id_fkey" on table "participant_sync_status"
  Detail: Key (id)=(xxx) is still referenced from table "participant_sync_status".
```

Korjaus testattu toimivaksi QA:lla.