### PR TITLE
Fix calls to kayttooikeus-service.

### DIFF
--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -15,7 +15,6 @@
                         :yki-host-virkailija       "{{host_ilb}}"
                         :cas-service-base          "http://cas.{{server_name}}.internal:8080"
                         :cas-oppija-service-base   "http://cas-oppija.{{server_name}}.internal:8080"
-                        :kayttooikeus-service-base "http://kayttooikeus.{{server_name}}.internal:8080"
                         :koodisto-service-base     "http://koodisto.{{server_name}}.internal:8080"
                         :onr-service-base          "http://oppijanumerorekisteri.{{server_name}}.internal:8080"
                         :organisaatio-service-base "http://organisaatio.{{server_name}}.internal:8080"}

--- a/resources/yki/yki-oph.properties
+++ b/resources/yki/yki-oph.properties
@@ -30,7 +30,7 @@ cas-oppija.logout.redirect-to-url=${cas-oppija-url}/logout?service=${cas-oppija.
 cas-oppija.validate-service = ${cas-oppija-service-base}/cas-oppija/serviceValidate
 
 kayttooikeus-service=${url-virkailija}/kayttooikeus-service
-kayttooikeus-service.kayttooikeus.kayttaja=${kayttooikeus-service-base}/kayttooikeus-service/kayttooikeus/kayttaja
+kayttooikeus-service.kayttooikeus.kayttaja=${kayttooikeus-service}/kayttooikeus/kayttaja
 
 onr-service=${url-virkailija}/oppijanumerorekisteri-service
 onr-service.person-by-ssn = ${onr-service-base}/oppijanumerorekisteri-service/henkilo/hetu=$1

--- a/src/yki/util/url_helper.clj
+++ b/src/yki/util/url_helper.clj
@@ -10,8 +10,8 @@
 
 (defmethod ig/init-key
   :yki.util/url-helper
-  [_ {:keys [virkailija-host oppija-host oppija-sub-domain yki-register-host yki-host-virkailija alb-host scheme cas-service-base cas-oppija-service-base kayttooikeus-service-base koodisto-service-base onr-service-base organisaatio-service-base]
-      :or   {virkailija-host "" oppija-host "" oppija-sub-domain "" yki-register-host "" yki-host-virkailija "" alb-host "" scheme "https" cas-service-base "" cas-oppija-service-base "" kayttooikeus-service-base "" koodisto-service-base "" onr-service-base "" organisaatio-service-base ""}}]
+  [_ {:keys [virkailija-host oppija-host oppija-sub-domain yki-register-host yki-host-virkailija alb-host scheme cas-service-base cas-oppija-service-base koodisto-service-base onr-service-base organisaatio-service-base]
+      :or   {virkailija-host "" oppija-host "" oppija-sub-domain "" yki-register-host "" yki-host-virkailija "" alb-host "" scheme "https" cas-service-base "" cas-oppija-service-base "" koodisto-service-base "" onr-service-base "" organisaatio-service-base ""}}]
   (reset! url-properties
           (doto (OphProperties. (into-array String ["/yki/yki-oph.properties"]))
             (.addDefault "scheme" scheme)
@@ -23,7 +23,6 @@
             (.addDefault "host-yki-virkailija" yki-host-virkailija)
             (.addDefault "cas-service-base" cas-service-base)
             (.addDefault "cas-oppija-service-base" cas-oppija-service-base)
-            (.addDefault "kayttooikeus-service-base" kayttooikeus-service-base)
             (.addDefault "koodisto-service-base" koodisto-service-base)
             (.addDefault "onr-service-base" onr-service-base)
             (.addDefault "organisaatio-service-base" organisaatio-service-base)))

--- a/test/yki/handler/base_test.clj
+++ b/test/yki/handler/base_test.clj
@@ -473,7 +473,6 @@
        :oppija-sub-domain         "yki."
        :cas-service-base          uri-with-schema
        :cas-oppija-service-base   uri
-       :kayttooikeus-service-base uri-with-schema
        :koodisto-service-base     uri-with-schema
        :onr-service-base          uri-with-schema
        :organisaatio-service-base uri-with-schema})))

--- a/test/yki/handler/virkailija_auth_test.clj
+++ b/test/yki/handler/virkailija_auth_test.clj
@@ -37,7 +37,6 @@
                                                                 :yki-register-host         uri
                                                                 :yki-host-virkailija       ""
                                                                 :cas-service-base          (str "http://" uri)
-                                                                :kayttooikeus-service-base (str "http://" uri)
                                                                 :onr-service-base          (str "http://" uri)
                                                                 :alb-host                  (str "http://" uri)
                                                                 :scheme                    "http"})


### PR DESCRIPTION
After the service was moved to a separate AWS account, it is no longer reachable through internal URLs. We need to go through public URLs instead.