### PR TITLE
Move access log stream to dedicated namespace

### DIFF
--- a/dev/resources/logback.xml
+++ b/dev/resources/logback.xml
@@ -59,7 +59,7 @@
     </root>
 
     <!-- Access Log -->
-    <logger name="ring.logger" level="INFO" additivity="false">
+    <logger name="yki.middleware.access-log" level="INFO" additivity="false">
         <appender-ref ref="ACCESS" />
     </logger>
 

--- a/oph-configuration/logback.xml.template
+++ b/oph-configuration/logback.xml.template
@@ -58,7 +58,7 @@
     </root>
 
     <!-- Access Log -->
-    <logger name="ring.logger" level="INFO" additivity="false">
+    <logger name="yki.middleware.access-log" level="INFO" additivity="false">
         <appender-ref ref="ACCESS" />
     </logger>
 

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -58,7 +58,7 @@
     </root>
 
     <!-- Access Log -->
-    <logger name="ring.logger" level="INFO" additivity="false">
+    <logger name="yki.middleware.access-log" level="INFO" additivity="false">
         <appender-ref ref="ACCESS" />
     </logger>
 

--- a/src/yki/middleware/access_log.clj
+++ b/src/yki/middleware/access_log.clj
@@ -38,4 +38,7 @@
   (fn with-logging [handler]
     (logger/wrap-log-response
       handler
-      {:transform-fn (env->log-transformer env), :request-keys request-keys})))
+      {:transform-fn (env->log-transformer env)
+       :request-keys request-keys
+       :log-fn (fn [{:keys [level throwable message]}]
+                  (clojure.tools.logging/log "yki.middleware.access-log" level throwable message))})))

--- a/test/resources/logback-test.xml
+++ b/test/resources/logback-test.xml
@@ -7,7 +7,7 @@
     </layout>
   </appender>
 
-    <logger name="ring.logger" level="OFF" additivity="false">
+    <logger name="yki.middleware.access-log" level="OFF" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
 


### PR DESCRIPTION
ring.loggeriin tulee kirjastoista virheitä (esim. loginiin liittyen), joten tulostetaan meidän omat access-lokit omaan namespaceen, jolloin muu ring.logger jää päälokiin.