### PR TITLE
Alter participant ONR status check logic

### DIFF
--- a/resources/yki/debug.sql
+++ b/resources/yki/debug.sql
@@ -1,15 +1,27 @@
 -- name: select-participant-onr-data
-SELECT * FROM participant_onr;
+SELECT participant_onr.*, last_exam_session.exam_date FROM participant_onr
+LEFT JOIN (SELECT r.participant_id, max(ed.exam_date) AS exam_date
+           FROM exam_date ed
+           JOIN exam_session es ON ed.id = es.exam_date_id
+           JOIN registration r ON es.id = r.exam_session_id
+           GROUP BY r.participant_id) last_exam_session
+ON last_exam_session.participant_id = participant_onr.participant_id
+WHERE is_individualized = false;
 
 -- name: select-participants-for-onr-check
 SELECT p.id AS participant_id, r.person_oid
 FROM registration r
 INNER JOIN participant p
 ON r.participant_id = p.id
+LEFT JOIN participant_onr onr
+ON onr.oid = r.person_oid
 WHERE r.person_oid IS NOT NULL
-AND NOT EXISTS
-    (SELECT oid FROM participant_onr
-     WHERE oid = r.person_oid);
+AND (   (onr.oid IS NULL
+         AND current_timestamp > r.created + interval '1 hour')
+     OR (onr.oid IS NOT NULL
+         AND onr.is_individualized = false
+         AND current_timestamp > onr.modified + interval '1 day'
+         AND r.created >= date '2024-10-01'));
 
 -- name: upsert-participant-onr-data!
 INSERT INTO participant_onr

--- a/src/yki/handler/debug.clj
+++ b/src/yki/handler/debug.clj
@@ -26,7 +26,7 @@
         ;:query-params [individualized :- boolean?]
         (let [participant-onr-data (->> (b/get-participant-onr-data db)
                                         (map #(with-onr-url url-helper %)))
-              columns              [:oid :oppijanumero :onr_url :participant_id :is_individualized :modified]
+              columns              [:oid :onr_url :participant_id :is_individualized :modified :exam_date]
               batch-size           1000]
           (with-open [writer (StringWriter.)]
             (csv/write-csv writer [(map name columns)] :separator \;)


### PR DESCRIPTION
- Add latest exam date participant registered on
- Only list participants who are not yet individualized
- Wait an hour before checking ONR status for the first time
- Update ONR data for participants who 1) were created after 2024-09-30 2) are not yet individualized according to our records 3) have not been checked in a day