### PR TITLE
Versiopäivityksiä: java-cas sekä muita minor-päivityksiä

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,10 +10,10 @@
                  ["ext-snapshots" "https://artifactory.opintopolku.fi/artifactory/ext-snapshot-local"]
                  ["Scalaz Bintray Repo" "https://dl.bintray.com/scalaz/releases"]]
   :min-lein-version "2.0.0"
-  :managed-dependencies [[com.fasterxml.jackson.core/jackson-annotations "2.18.3"]
-                         [com.fasterxml.jackson.core/jackson-core "2.18.3"]
-                         [com.fasterxml.jackson.core/jackson-databind "2.18.3"]
-                         [com.fasterxml.jackson.datatype/jackson-datatype-jsr310 "2.18.3"]
+  :managed-dependencies [[com.fasterxml.jackson.core/jackson-annotations "2.19.0"]
+                         [com.fasterxml.jackson.core/jackson-core "2.19.0"]
+                         [com.fasterxml.jackson.core/jackson-databind "2.19.0"]
+                         [com.fasterxml.jackson.datatype/jackson-datatype-jsr310 "2.19.0"]
                          ; [com.layerware/pgqueue "0.5.1"] depends on a version of nippy with a known vulnerability
                          ; as there is no update for pgqueue available, let's instead fix the nippy version here
                          [com.taoensso/nippy "2.15.3"]]
@@ -42,7 +42,7 @@
                  [webjure/jeesql "0.4.7"]
                  [http-kit "2.8.0"]
                  [ring-logger "1.1.1"]
-                 [ch.qos.logback/logback-classic "1.5.17"]
+                 [ch.qos.logback/logback-classic "1.5.18"]
                  [org.clojure/data.xml "0.0.8"]
                  [fi.vm.sade.java-utils/java-cas "1.2.3-SNAPSHOT"
                   :exclusions [org.slf4j/slf4j-simple]]
@@ -97,8 +97,8 @@
                                          [eftest "0.6.0"]
                                          [peridot "0.5.4"]
                                          [se.haleby/stub-http "0.2.14"]
-                                         [com.opentable.components/otj-pg-embedded "1.1.0"]
+                                         [com.opentable.components/otj-pg-embedded "1.1.1"]
                                          [kerodon "0.9.1"]
-                                         [com.clojure-goes-fast/clj-async-profiler "1.6.1"]]
-                  :managed-dependencies [[org.testcontainers/testcontainers "1.20.6"]
-                                         [org.testcontainers/postgresql "1.20.6"]]}})
+                                         [com.clojure-goes-fast/clj-async-profiler "1.6.2"]]
+                  :managed-dependencies [[org.testcontainers/testcontainers "1.21.0"]
+                                         [org.testcontainers/postgresql "1.21.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
                  [ring-logger "1.1.1"]
                  [ch.qos.logback/logback-classic "1.5.17"]
                  [org.clojure/data.xml "0.0.8"]
-                 [fi.vm.sade.java-utils/java-cas "1.2.2-SNAPSHOT"
+                 [fi.vm.sade.java-utils/java-cas "1.2.3-SNAPSHOT"
                   :exclusions [org.slf4j/slf4j-simple]]
                  [fi.vm.sade/auditlogger "9.2.4-SNAPSHOT"]
                  [fi.vm.sade.java-utils/java-properties "0.1.0-SNAPSHOT"]


### PR DESCRIPTION
Korjaa ongelman virkailijan CAS-tiketin validoinnissa. `java-cas`in aiempi versio lähettää tiketin useampaan otteeseen query parametrinä, mistä uusi CAS-palvelinversio ei tykkää. Tämä korjaantuu `java-cas`in versiossa 1.2.3.