### PR TITLE
Prevent migrations run twice

### DIFF
--- a/src/yki/migrations.clj
+++ b/src/yki/migrations.clj
@@ -3,4 +3,4 @@
             [ragtime.jdbc :as ragtime-jdbc]))
 
 (defmethod ig/init-key :yki/migrations [_ _]
-  (vec (ragtime-jdbc/load-resources "yki/migrations")))
+  (vec (ragtime-jdbc/load-directory "resources/yki/migrations")))


### PR DESCRIPTION
When using load-resources, the migrations may run the same migration file twice.

This seems to be a bug in ragtime: https://github.com/weavejester/ragtime/issues/155#issuecomment-1286724490