### PR TITLE
OPHKIOS-287: Tekstikorjauksia

### DIFF
--- a/resources/yki/templates/free_registration_from_queue.html
+++ b/resources/yki/templates/free_registration_from_queue.html
@@ -3,7 +3,8 @@
   <td style="padding-left: 20px;">
     {% i18n email.free_registration_from_queue.content.line1 %}
     <b>{% i18n email.free_registration.content.line1.part1 %}</b>
-    {% i18n email.free_registration.content.line1.part2 %}:
+    {% i18n email.free_registration.content.line1.part2 %}
+    {% i18n email.free_registration.content.line1.part3 %}:
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
Lisätty templatesta epähuomiossa pois jäänyt lause:
<img width="427" height="133" alt="Screenshot 2025-12-16 at 11 00 12" src="https://github.com/user-attachments/assets/9f41741b-dab4-471c-a0c7-c20fd7bde21e" />
