### PR TITLE
Set correct expiration date for payment link when lifting from queue

### DIFF
--- a/src/yki/boundary/registration_db.clj
+++ b/src/yki/boundary/registration_db.clj
@@ -50,6 +50,10 @@
   (expire-queued-registrations-after-exam-date! [db])
   (get-free-registration [db registration-id]))
 
+(defn get-registration-data-with-tx
+         [tx registration-id participant-id lang]
+         (first (q/select-registration-data tx {:id registration-id :participant_id participant-id :lang lang})))
+
 (defn- expire-registrations! [tx ids]
   (when (seq ids)
     (let [expired (q/expire-registrations-by-ids! tx {:ids ids})]
@@ -248,7 +252,7 @@
                      {:event       "LIFT_FROM_QUEUE"
                       :author_type "AUTOMATION"
                       :created_by  nil}))
-            (send-email! registration))))))
+            (send-email! tx registration))))))
   (expire-queued-registrations-after-exam-date! [{:keys [spec]}]
     (jdbc/with-db-transaction [tx spec]
       (let [ids (->> (q/select-queued-registrations-to-expire tx)

--- a/src/yki/job/scheduled_tasks.clj
+++ b/src/yki/job/scheduled_tasks.clj
@@ -196,9 +196,9 @@
   #(try
      (when (job-db/try-to-acquire-lock! db registration-queue-handler-conf)
        (log/info "Registration queue handler started")
-       (let [create-and-send-payment-link! (fn [{:keys [id participant_id ui_language]}]
+       (let [create-and-send-payment-link! (fn [tx {:keys [id participant_id ui_language]}]
                                              (let [lang                (or ui_language "fi")
-                                                   email-template-data (registration-db/get-registration-data db id participant_id lang)
+                                                   email-template-data (registration-db/get-registration-data-with-tx tx id participant_id lang)
                                                    code                (str (random-uuid))
                                                    login-url           (url-helper :yki.login-link.url code)
                                                    free?               (:free_registration_id email-template-data)]


### PR DESCRIPTION
Payment link was generated outside of transaction, which caused it to read the old expiration date, which was set before lifting from queue.