### PR TITLE
OPHKIOS-303 & OPHKIOS-359: osakokeiden ja tutkintotilaisuuksien siirto Solki-järjestelmään

### DIFF
--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -45,6 +45,12 @@
                                                :url-helper #ig/ref :yki.util/url-helper
                                                :retry-duration-in-days 1}
 
+:yki.job.scheduled-tasks/exam-session-solki-sync-handler {:db         #ig/ref :duct.database/sql
+                                                          :disabled   {{yki_register_exam_session_sync_disabled}}
+                                                          :basic-auth {:user     "{{yki_register_user}}"
+                                                                       :password "{{yki_register_password}}"}
+                                                          :url-helper #ig/ref :yki.util/url-helper}
+
 :yki.job.scheduled-tasks/data-sync-queue-reader {:data-sync-q  #ig/ref :yki.job.job-queue/data-sync-q
                                                  :db #ig/ref :duct.database/sql
                                                  :disabled {{yki_register_exam_session_sync_disabled}}

--- a/resources/yki/config.edn
+++ b/resources/yki/config.edn
@@ -102,6 +102,11 @@
 
   :yki.job.scheduled-tasks/exam-session-statistics-handler   {:db #ig/ref :duct.database/sql}
 
+  :yki.job.scheduled-tasks/exam-session-solki-sync-handler   {:db         #ig/ref :duct.database/sql
+                                                              :disabled   true
+                                                              :basic-auth {:user "user" :password "pass"}
+                                                              :url-helper #ig/ref :yki.util/url-helper}
+
   :duct.scheduler/simple
   {:thread-pool-size 10
    :jobs             [{:interval 60 :delay 60 :run #ig/ref :yki.job.scheduled-tasks/registration-state-handler}
@@ -113,7 +118,8 @@
                       {:interval 60 :delay 60 :run #ig/ref :yki.job.scheduled-tasks/registration-queue-handler}
                       {:interval 60 :delay 100 :run #ig/ref :yki.job.scheduled-tasks/migrate-person-handler}
                       {:interval 60 :delay 60 :run #ig/ref :yki.job.scheduled-tasks/persons-sync-handler}
-                      {:interval 1800 :delay 60 :run #ig/ref :yki.job.scheduled-tasks/exam-session-statistics-handler}]}
+                      {:interval 1800 :delay 60 :run #ig/ref :yki.job.scheduled-tasks/exam-session-statistics-handler}
+                      {:interval 3600 :delay 60 :run #ig/ref :yki.job.scheduled-tasks/exam-session-solki-sync-handler}]}
 
   :yki.boundary.cas/cas-client                               {:url-helper #ig/ref :yki.util/url-helper
                                                               :cas-creds  {}}

--- a/resources/yki/migrations/048-add-partial-exam-type-to-registration.0.1.0.up.sql
+++ b/resources/yki/migrations/048-add-partial-exam-type-to-registration.0.1.0.up.sql
@@ -1,0 +1,15 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'exam_session_type') THEN
+    CREATE TYPE exam_session_type AS ENUM ('FULL','READ_SPEAK','LISTEN_WRITE');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'exam_session_ticket_type') THEN
+    CREATE TYPE exam_session_ticket_type AS ENUM ('ALL_PARTS','READ','SPEAK','LISTEN','WRITE');
+  END IF;
+END$$;
+
+ALTER TABLE exam_session
+  ADD COLUMN IF NOT EXISTS type exam_session_type NOT NULL DEFAULT 'FULL';
+
+ALTER TABLE registration
+  ADD COLUMN IF NOT EXISTS partial_exam_type exam_session_ticket_type NOT NULL DEFAULT 'ALL_PARTS';

--- a/resources/yki/migrations/049-add-last-sync-at-to-exam-session.0.1.0.up.sql
+++ b/resources/yki/migrations/049-add-last-sync-at-to-exam-session.0.1.0.up.sql
@@ -1,4 +1,4 @@
-ALTER TABLE exam_session ADD COLUMN IF NOT EXISTS last_sync_at TIMESTAMPTZ DEFAULT NULL;
+ALTER TABLE exam_session ADD COLUMN IF NOT EXISTS last_sync_at TIMESTAMP WITH TIME ZONE DEFAULT NULL;
 
 UPDATE exam_session SET last_sync_at = NOW() WHERE last_sync_at IS NULL;
 

--- a/resources/yki/migrations/049-add-last-sync-at-to-exam-session.0.1.0.up.sql
+++ b/resources/yki/migrations/049-add-last-sync-at-to-exam-session.0.1.0.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE exam_session ADD COLUMN IF NOT EXISTS last_sync_at TIMESTAMPTZ DEFAULT NULL;
+
+UPDATE exam_session SET last_sync_at = NOW() WHERE last_sync_at IS NULL;
+
+INSERT INTO task_lock (task, last_executed)
+VALUES ('EXAM_SESSION_SOLKI_SYNC_HANDLER', '-infinity');

--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -1262,11 +1262,25 @@ DELETE FROM participant_sync_status
 WHERE exam_session_id = :exam_session_id;
 
 -- name: select-completed-exam-session-participants
-SELECT r.form, r.person_oid, r.is_transfered, p.last_name, p.first_name, p.email, p.zip, p.post_office, p.street_address, p.country_code
+SELECT r.form,
+       r.person_oid,
+       r.is_transfered,
+       r.partial_exam_type,
+       es.type AS exam_session_type,
+       p.last_name,
+       p.first_name,
+       p.email,
+       p.zip,
+       p.post_office,
+       p.street_address,
+       p.country_code
 FROM registration r
+INNER JOIN exam_session es ON es.id = r.exam_session_id
 INNER JOIN person p ON p.oid = r.person_oid
-WHERE r.exam_session_id = :id
-AND r.state = 'COMPLETED';
+WHERE es.exam_date_id = (SELECT exam_date_id FROM exam_session WHERE id = :id)
+  AND es.organizer_id = (SELECT organizer_id FROM exam_session WHERE id = :id)
+  AND r.state = 'COMPLETED'
+ORDER BY r.id ASC;
 
 -- name: select-exam-session-participants
 SELECT

--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -266,7 +266,8 @@ INSERT INTO exam_session (
   exam_date_id,
   max_participants,
   office_oid,
-  published_at
+  published_at,
+  last_sync_at
 ) VALUES (
   (SELECT id FROM organizer
     WHERE oid = :oid AND deleted_at IS NULL AND agreement_end_date >= :session_date AND agreement_start_date <= :session_date
@@ -282,7 +283,8 @@ INSERT INTO exam_session (
   (SELECT id from exam_date WHERE exam_date = :session_date AND deleted_at IS NULL),
   :max_participants,
   :office_oid,
-  :published_at
+  :published_at,
+  NOW()
 );
 
 -- name: insert-exam-session-location!
@@ -1245,7 +1247,26 @@ WHERE (((ed.exam_date >= (current_date + interval '1 week' - :duration::interval
   AND (SELECT COUNT(1)
        FROM registration re
        WHERE re.exam_session_id = es.id
-         AND re.state = 'COMPLETED') > 0;
+         AND re.state = 'COMPLETED') > 0
+  AND es.last_sync_at IS NOT NULL;
+
+-- name: select-unsynced-exam-sessions
+SELECT es.id,
+       es.language_code,
+       es.level_code,
+       ed.exam_date AS session_date,
+       o.oid        AS organizer_oid,
+       es.office_oid
+FROM exam_session es
+INNER JOIN exam_date ed ON es.exam_date_id = ed.id
+INNER JOIN organizer o ON es.organizer_id = o.id
+WHERE es.last_sync_at IS NULL
+  AND ed.exam_date >= current_date;
+
+-- name: set-exam-session-last-sync-at!
+UPDATE exam_session
+SET last_sync_at = current_timestamp
+WHERE id = :id;
 
 -- name: update-participant-sync-to-success!
 UPDATE participant_sync_status

--- a/src/yki/boundary/exam_session_db.clj
+++ b/src/yki/boundary/exam_session_db.clj
@@ -83,6 +83,8 @@
   (get-exam-session-participants [db id oid])
   (get-completed-exam-session-participants [db id])
   (get-exam-sessions-to-be-synced [db retry-duration])
+  (get-unsynced-exam-sessions [db])
+  (set-exam-session-synced! [db id])
   (get-exam-sessions [db from]
     "Get exam sessions with exam date at least 'from'")
   (get-exam-sessions-for-oid [db oid from]
@@ -203,6 +205,11 @@
     (first (q/select-exam-session-registration-by-registration-id spec {:registration_id registration-id})))
   (get-exam-sessions-to-be-synced [{:keys [spec]} retry-duration]
     (q/select-exam-sessions-to-be-synced spec {:duration retry-duration}))
+  (get-unsynced-exam-sessions [{:keys [spec]}]
+    (q/select-unsynced-exam-sessions spec))
+  (set-exam-session-synced! [{:keys [spec]} id]
+    (jdbc/with-db-transaction [tx spec]
+      (q/set-exam-session-last-sync-at! tx {:id id})))
   (get-exam-session-participants [{:keys [spec]} id oid]
     (q/select-exam-session-participants spec {:id id :oid oid}))
   (get-completed-exam-session-participants [{:keys [spec]} id]

--- a/src/yki/boundary/yki_register.clj
+++ b/src/yki/boundary/yki_register.clj
@@ -148,7 +148,42 @@
         (do-post (url-helper :yki-register.exam-date) (json/write-value-as-string exam-date-req) basic-auth)
         (do-post (url-helper :yki-register.exam-session) (json/write-value-as-string exam-session-req) basic-auth)))))
 
-(defn participant->csv-record [url-helper oid->ssn {:keys [form is_transfered person_oid last_name first_name email zip post_office street_address country_code]}]
+(defn session-type->subtest-flags [session-type partial-exam-type]
+  (let [part (or partial-exam-type "ALL_PARTS")]
+    (case (or session-type "FULL")
+      "READ_SPEAK"   {:speak  (if (contains? #{"ALL_PARTS" "SPEAK"} part) 1 0)
+                      :write  0
+                      :listen 0
+                      :read   (if (contains? #{"ALL_PARTS" "READ"} part) 1 0)}
+      "LISTEN_WRITE" {:speak  0
+                      :write  (if (contains? #{"ALL_PARTS" "WRITE"} part) 1 0)
+                      :listen (if (contains? #{"ALL_PARTS" "LISTEN"} part) 1 0)
+                      :read   0}
+                     {:speak  (if (contains? #{"ALL_PARTS" "SPEAK"} part) 1 0)
+                      :write  (if (contains? #{"ALL_PARTS" "WRITE"} part) 1 0)
+                      :listen (if (contains? #{"ALL_PARTS" "LISTEN"} part) 1 0)
+                      :read   (if (contains? #{"ALL_PARTS" "READ"} part) 1 0)})))
+
+(defn- merge-flags [flags-list]
+  (reduce (fn [a b] (merge-with max a b))
+          {:speak 0 :write 0 :listen 0 :read 0}
+          flags-list))
+
+(defn merge-participants [participants]
+  (->> participants
+       (group-by :person_oid)
+       (vals)
+       (map (fn [rows]
+              (let [flags (merge-flags
+                            (map #(session-type->subtest-flags
+                                    (:exam_session_type %)
+                                    (:partial_exam_type %))
+                                 rows))]
+                (merge (first rows)
+                       flags
+                       {:is_transfered (boolean (some :is_transfered rows))}))))))
+
+(defn participant->csv-record [url-helper oid->ssn {:keys [form is_transfered person_oid last_name first_name email zip post_office street_address country_code speak write listen read]}]
   (let [{:keys [gender nationalities birthdate certificate_lang exam_lang]} form
         nationality (codes/get-converted-country-code url-helper (first nationalities))
         country     (codes/get-converted-country-code url-helper country_code)
@@ -166,11 +201,16 @@
      email
      exam_lang
      certificate_lang
-     (if is_transfered 1 0)]))
+     (if is_transfered 1 0)
+     speak
+     write
+     listen
+     read]))
 
 (defn create-participants-csv [url-helper participants oid->ssn]
   (with-open [writer (StringWriter.)]
-    (let [csv-data (map #(participant->csv-record url-helper oid->ssn %) participants)]
+    (let [csv-data (->> (merge-participants participants)
+                        (map #(participant->csv-record url-helper oid->ssn %)))]
       (csv/write-csv writer csv-data :separator \;))
     (.toString writer)))
 

--- a/src/yki/boundary/yki_register.clj
+++ b/src/yki/boundary/yki_register.clj
@@ -204,8 +204,8 @@
      (if is_transfered 1 0)
      speak
      write
-     listen
-     read]))
+     read
+     listen]))
 
 (defn create-participants-csv [url-helper participants oid->ssn]
   (with-open [writer (StringWriter.)]

--- a/src/yki/job/scheduled_tasks.clj
+++ b/src/yki/job/scheduled_tasks.clj
@@ -49,6 +49,10 @@
                                                :task      "EXAM_SESSION_STATISTICS_HANDLER"
                                                :interval  "57 MINUTES"})
 
+(defonce exam-session-solki-sync-handler-conf {:worker-id (str (random-uuid))
+                                               :task      "EXAM_SESSION_SOLKI_SYNC_HANDLER"
+                                               :interval  "59 MINUTES"})
+
 (defn- take-with-error-handling
   "Takes message from queue and executes handler function with message.
   Rethrows exceptions if retry until limit is not reached so that message is not
@@ -339,3 +343,22 @@
              (exam-session-db/update-exam-session-statistics! db statistics-to-insert)))))
      (catch Exception e
        (log/error e "Exam session statistics handler failed [ERROR_SCHEDULED_TASK]"))))
+
+(defmethod ig/init-key ::exam-session-solki-sync-handler
+  [_ {:keys [db url-helper basic-auth disabled]}]
+  {:pre [(some? db) (some? url-helper) (some? basic-auth)]}
+  #(try
+     (when (job-db/try-to-acquire-lock! db exam-session-solki-sync-handler-conf)
+       (log/info "Exam session Solki sync handler started")
+       (let [unsynced-sessions (exam-session-db/get-unsynced-exam-sessions db)]
+         (log/info "Found unsynced exam sessions" (map :id unsynced-sessions))
+         (doseq [exam-session unsynced-sessions]
+           (try
+             (yki-register/sync-exam-session-and-organizer db url-helper basic-auth disabled
+                                                           {:type         "CREATE"
+                                                            :exam-session exam-session})
+             (exam-session-db/set-exam-session-synced! db (:id exam-session))
+             (catch Exception e
+               (log/error e "Failed to sync exam session to Solki" {:id (:id exam-session)}))))))
+     (catch Exception e
+       (log/error e "Exam session Solki sync handler failed [ERROR_SCHEDULED_TASK]"))))

--- a/test/yki/boundary/yki_register_test.clj
+++ b/test/yki/boundary/yki_register_test.clj
@@ -333,6 +333,7 @@
   (base/insert-base-data)
   (base/insert-persons)
   (base/insert-registrations "COMPLETED")
+  (jdbc/execute! @embedded-db/conn "UPDATE exam_session SET last_sync_at = NOW()")
   (let [exam-session-id (:id (base/select-one base/select-exam-session))
         exam-date-id    (:exam_date_id (base/select-one (str "SELECT exam_date_id FROM exam_session WHERE id=" exam-session-id)))
         db              (base/db)

--- a/test/yki/boundary/yki_register_test.clj
+++ b/test/yki/boundary/yki_register_test.clj
@@ -218,20 +218,20 @@
                     :zip "33100" :post_office "Tampere" :street_address "Linja 1" :country_code nil}
           url-helper (base/create-url-helper (str "localhost:" port))
           oid->ssn   {"1.2.3.4.5" "150690-900T"}]
-      (testing "READ_SPEAK/ALL_PARTS flags: speak=1 write=0 listen=0 read=1"
+      (testing "READ_SPEAK/ALL_PARTS flags: speak=1 write=0 read=1 listen=0"
         (let [result (yki-register/participant->csv-record url-helper oid->ssn
                                                            (assoc base-map :speak 1 :write 0 :listen 0 :read 1))]
           (is (= 1 (nth result 14)))
           (is (= 0 (nth result 15)))
-          (is (= 0 (nth result 16)))
-          (is (= 1 (nth result 17)))))
-      (testing "LISTEN_WRITE/ALL_PARTS flags: speak=0 write=1 listen=1 read=0"
+          (is (= 1 (nth result 16)))
+          (is (= 0 (nth result 17)))))
+      (testing "LISTEN_WRITE/ALL_PARTS flags: speak=0 write=1 read=0 listen=1"
         (let [result (yki-register/participant->csv-record url-helper oid->ssn
                                                            (assoc base-map :speak 0 :write 1 :listen 1 :read 0))]
           (is (= 0 (nth result 14)))
           (is (= 1 (nth result 15)))
-          (is (= 1 (nth result 16)))
-          (is (= 0 (nth result 17)))))
+          (is (= 0 (nth result 16)))
+          (is (= 1 (nth result 17)))))
       (testing "single subtest SPEAK only: speak=1 rest=0"
         (let [result (yki-register/participant->csv-record url-helper oid->ssn
                                                            (assoc base-map :speak 1 :write 0 :listen 0 :read 0))]
@@ -260,12 +260,12 @@
                                          :birthdate "2000-01-01"
                                          :certificate_lang "fi" :exam_lang "fi"}})
           participants [(make-row "p1" "FULL"         "ALL_PARTS")   ; → 1 1 1 1
-                        (make-row "p2" "READ_SPEAK"   "ALL_PARTS")   ; → 1 0 0 1
-                        (make-row "p3" "LISTEN_WRITE" "ALL_PARTS")   ; → 0 1 1 0
+                        (make-row "p2" "READ_SPEAK"   "ALL_PARTS")   ; → 1 0 1 0
+                        (make-row "p3" "LISTEN_WRITE" "ALL_PARTS")   ; → 0 1 0 1
                         (make-row "p4" "READ_SPEAK"   "ALL_PARTS")   ; \  merged
                         (make-row "p4" "LISTEN_WRITE" "ALL_PARTS")   ; /  → 1 1 1 1
                         (make-row "p5" "READ_SPEAK"   "SPEAK")       ; \  merged
-                        (make-row "p5" "LISTEN_WRITE" "LISTEN")]     ; /  → 1 0 1 0
+                        (make-row "p5" "LISTEN_WRITE" "LISTEN")]     ; /  → 1 0 0 1
           csv-str (yki-register/create-participants-csv url-helper participants oid->ssn)
           rows    (str/split csv-str #"\n")
           fields  (fn [row-str] (str/split row-str #";"))]
@@ -274,18 +274,18 @@
       (testing "p1 FULL/ALL_PARTS → speak=1 write=1 listen=1 read=1"
         (let [f (fields (first (filter #(str/starts-with? % "p1") rows)))]
           (is (= ["1" "1" "1" "1"] (subvec (vec f) 14 18)))))
-      (testing "p2 READ_SPEAK/ALL_PARTS → speak=1 write=0 listen=0 read=1"
+      (testing "p2 READ_SPEAK/ALL_PARTS → speak=1 write=0 read=1 listen=0"
         (let [f (fields (first (filter #(str/starts-with? % "p2") rows)))]
-          (is (= ["1" "0" "0" "1"] (subvec (vec f) 14 18)))))
-      (testing "p3 LISTEN_WRITE/ALL_PARTS → speak=0 write=1 listen=1 read=0"
+          (is (= ["1" "0" "1" "0"] (subvec (vec f) 14 18)))))
+      (testing "p3 LISTEN_WRITE/ALL_PARTS → speak=0 write=1 read=0 listen=1"
         (let [f (fields (first (filter #(str/starts-with? % "p3") rows)))]
-          (is (= ["0" "1" "1" "0"] (subvec (vec f) 14 18)))))
+          (is (= ["0" "1" "0" "1"] (subvec (vec f) 14 18)))))
       (testing "p4 READ_SPEAK+LISTEN_WRITE both ALL_PARTS → merged speak=1 write=1 listen=1 read=1"
         (let [f (fields (first (filter #(str/starts-with? % "p4") rows)))]
           (is (= ["1" "1" "1" "1"] (subvec (vec f) 14 18)))))
-      (testing "p5 READ_SPEAK/SPEAK + LISTEN_WRITE/LISTEN → merged speak=1 write=0 listen=1 read=0"
+      (testing "p5 READ_SPEAK/SPEAK + LISTEN_WRITE/LISTEN → merged speak=1 write=0 read=0 listen=1"
         (let [f (fields (first (filter #(str/starts-with? % "p5") rows)))]
-          (is (= ["1" "0" "1" "0"] (subvec (vec f) 14 18))))))))
+          (is (= ["1" "0" "0" "1"] (subvec (vec f) 14 18))))))))
 
 ;; ──────────────────────────────────────────────────────────────────────────────
 ;; sync-exam-session-participants — full integration against embedded DB

--- a/test/yki/boundary/yki_register_test.clj
+++ b/test/yki/boundary/yki_register_test.clj
@@ -38,6 +38,129 @@
     (testing "exam session sync request is valid"
       (is (= exam-session-req assert-exam-session-req)))))
 
+;; ──────────────────────────────────────────────────────────────────────────────
+;; session-type->subtest-flags
+;; ──────────────────────────────────────────────────────────────────────────────
+
+(deftest session-type->subtest-flags-test
+  (testing "FULL session"
+    (is (= {:speak 1 :write 1 :listen 1 :read 1} (yki-register/session-type->subtest-flags "FULL" "ALL_PARTS")))
+    (is (= {:speak 1 :write 0 :listen 0 :read 0} (yki-register/session-type->subtest-flags "FULL" "SPEAK")))
+    (is (= {:speak 0 :write 1 :listen 0 :read 0} (yki-register/session-type->subtest-flags "FULL" "WRITE")))
+    (is (= {:speak 0 :write 0 :listen 1 :read 0} (yki-register/session-type->subtest-flags "FULL" "LISTEN")))
+    (is (= {:speak 0 :write 0 :listen 0 :read 1} (yki-register/session-type->subtest-flags "FULL" "READ"))))
+
+  (testing "READ_SPEAK session"
+    (is (= {:speak 1 :write 0 :listen 0 :read 1} (yki-register/session-type->subtest-flags "READ_SPEAK" "ALL_PARTS")))
+    (is (= {:speak 1 :write 0 :listen 0 :read 0} (yki-register/session-type->subtest-flags "READ_SPEAK" "SPEAK")))
+    (is (= {:speak 0 :write 0 :listen 0 :read 1} (yki-register/session-type->subtest-flags "READ_SPEAK" "READ")))
+    (testing "invalid combos yield 0 — WRITE and LISTEN are not offered in READ_SPEAK"
+      (is (= 0 (:write  (yki-register/session-type->subtest-flags "READ_SPEAK" "ALL_PARTS"))))
+      (is (= 0 (:listen (yki-register/session-type->subtest-flags "READ_SPEAK" "ALL_PARTS"))))
+      (is (= {:speak 0 :write 0 :listen 0 :read 0} (yki-register/session-type->subtest-flags "READ_SPEAK" "WRITE")))
+      (is (= {:speak 0 :write 0 :listen 0 :read 0} (yki-register/session-type->subtest-flags "READ_SPEAK" "LISTEN")))))
+
+  (testing "LISTEN_WRITE session"
+    (is (= {:speak 0 :write 1 :listen 1 :read 0} (yki-register/session-type->subtest-flags "LISTEN_WRITE" "ALL_PARTS")))
+    (is (= {:speak 0 :write 1 :listen 0 :read 0} (yki-register/session-type->subtest-flags "LISTEN_WRITE" "WRITE")))
+    (is (= {:speak 0 :write 0 :listen 1 :read 0} (yki-register/session-type->subtest-flags "LISTEN_WRITE" "LISTEN")))
+    (testing "invalid combos yield 0 — SPEAK and READ are not offered in LISTEN_WRITE"
+      (is (= 0 (:speak (yki-register/session-type->subtest-flags "LISTEN_WRITE" "ALL_PARTS"))))
+      (is (= 0 (:read  (yki-register/session-type->subtest-flags "LISTEN_WRITE" "ALL_PARTS"))))
+      (is (= {:speak 0 :write 0 :listen 0 :read 0} (yki-register/session-type->subtest-flags "LISTEN_WRITE" "SPEAK")))
+      (is (= {:speak 0 :write 0 :listen 0 :read 0} (yki-register/session-type->subtest-flags "LISTEN_WRITE" "READ")))))
+
+  (testing "nil session type falls through to FULL branch"
+    (is (= {:speak 1 :write 1 :listen 1 :read 1} (yki-register/session-type->subtest-flags nil "ALL_PARTS")))
+    (is (= {:speak 1 :write 0 :listen 0 :read 0} (yki-register/session-type->subtest-flags nil "SPEAK")))))
+
+;; ──────────────────────────────────────────────────────────────────────────────
+;; merge-participants
+;; ──────────────────────────────────────────────────────────────────────────────
+
+(def ^:private base-participant
+  {:person_oid    "1.1.1.1"
+   :last_name     "Testi"
+   :first_name    "Henkilö"
+   :email         "t@test.fi"
+   :zip           "00100"
+   :post_office   "Helsinki"
+   :street_address "Testikatu 1"
+   :country_code  nil
+   :is_transfered false
+   :form          {:gender nil :nationalities nil :birthdate "2000-01-01"
+                   :certificate_lang "fi" :exam_lang "fi"}})
+
+(defn- row [person-oid session-type partial-type & [transferred?]]
+  (assoc base-participant
+         :person_oid person-oid
+         :exam_session_type session-type
+         :partial_exam_type partial-type
+         :is_transfered (boolean transferred?)))
+
+(deftest merge-participants-test
+  (testing "single FULL/ALL_PARTS registration → all 1s"
+    (let [result (first (yki-register/merge-participants [(row "p1" "FULL" "ALL_PARTS")]))]
+      (is (= 1 (:speak result)))
+      (is (= 1 (:write result)))
+      (is (= 1 (:listen result)))
+      (is (= 1 (:read result)))))
+
+  (testing "READ_SPEAK/ALL_PARTS + LISTEN_WRITE/ALL_PARTS → all 1s (full exam across two sessions)"
+    (let [result (first (yki-register/merge-participants [(row "p1" "READ_SPEAK" "ALL_PARTS")
+                                                          (row "p1" "LISTEN_WRITE" "ALL_PARTS")]))]
+      (is (= 1 (:speak result)))
+      (is (= 1 (:write result)))
+      (is (= 1 (:listen result)))
+      (is (= 1 (:read result)))))
+
+  (testing "READ_SPEAK/SPEAK + LISTEN_WRITE/WRITE → only speaking and writing"
+    (let [result (first (yki-register/merge-participants [(row "p1" "READ_SPEAK" "SPEAK")
+                                                          (row "p1" "LISTEN_WRITE" "WRITE")]))]
+      (is (= 1 (:speak result)))
+      (is (= 1 (:write result)))
+      (is (= 0 (:listen result)))
+      (is (= 0 (:read result)))))
+
+  (testing "READ_SPEAK/ALL_PARTS only → speak and read, no write or listen"
+    (let [result (first (yki-register/merge-participants [(row "p1" "READ_SPEAK" "ALL_PARTS")]))]
+      (is (= 1 (:speak result)))
+      (is (= 0 (:write result)))
+      (is (= 0 (:listen result)))
+      (is (= 1 (:read result)))))
+
+  (testing "LISTEN_WRITE/LISTEN only → only listen"
+    (let [result (first (yki-register/merge-participants [(row "p1" "LISTEN_WRITE" "LISTEN")]))]
+      (is (= 0 (:speak result)))
+      (is (= 0 (:write result)))
+      (is (= 1 (:listen result)))
+      (is (= 0 (:read result)))))
+
+  (testing "is_transfered: true in one of two rows → merged result is true"
+    (let [result (first (yki-register/merge-participants [(row "p1" "FULL" "ALL_PARTS" true)
+                                                          (row "p1" "FULL" "ALL_PARTS" false)]))]
+      (is (true? (:is_transfered result)))))
+
+  (testing "is_transfered: false in all rows → merged result is false"
+    (let [result (first (yki-register/merge-participants [(row "p1" "FULL" "ALL_PARTS" false)
+                                                          (row "p1" "FULL" "ALL_PARTS" false)]))]
+      (is (false? (:is_transfered result)))))
+
+  (testing "multiple persons are kept separate"
+    (let [results (yki-register/merge-participants [(row "p1" "FULL" "ALL_PARTS")
+                                                    (row "p2" "READ_SPEAK" "ALL_PARTS")])]
+      (is (= 2 (count results)))))
+
+  (testing "personal info is taken from first row"
+    (let [result (first (yki-register/merge-participants [(row "p1" "READ_SPEAK" "ALL_PARTS")
+                                                          (row "p1" "LISTEN_WRITE" "ALL_PARTS")]))]
+      (is (= "p1" (:person_oid result)))
+      (is (= "Testi" (:last_name result))))))
+
+;; ──────────────────────────────────────────────────────────────────────────────
+;; participant->csv-record — existing tests updated + new flag-position test
+;; ──────────────────────────────────────────────────────────────────────────────
+
 (deftest create-participant-csv-line-test
   (with-routes!
     {"/koodisto-service/rest/json/relaatio/rinnasteinen/maatjavaltiot2_246" {:status 200 :content-type "application/json"
@@ -48,20 +171,22 @@
         (testing "should create valid csv line with birth date"
           (let [participant (merge {:form          (apply dissoc base/registration-form person-fields)
                                     :person_oid    "5.4.3.2.1"
-                                    :is_transfered false}
+                                    :is_transfered false
+                                    :speak 1 :write 1 :listen 1 :read 1}
                                    (select-keys base/registration-form person-fields))
                 result      (yki-register/participant->csv-record (base/create-url-helper (str "localhost:" port)) {"5.4.3.2.1" "010199-9012"} participant)
-                csv-record  ["5.4.3.2.1" "010199-9012" "Ankka" "Aku" "M" "xxx" "Katu 3" "12345" "Ankkalinna" "FIN" "aa@al.fi" "fi" "fi" 0]]
+                csv-record  ["5.4.3.2.1" "010199-9012" "Ankka" "Aku" "M" "xxx" "Katu 3" "12345" "Ankkalinna" "FIN" "aa@al.fi" "fi" "fi" 0 1 1 1 1]]
             (is (= result csv-record))))
 
         (testing "should create valid csv line with ssn"
           (let [registration-form-with-ssn (dissoc (assoc base/registration-form :ssn "010199-9034" :nationalities ["246"] :country_code "246") :gender)
                 participant                (merge {:form          (apply dissoc registration-form-with-ssn person-fields)
                                                    :person_oid    "5.4.3.2.1"
-                                                   :is_transfered true}
+                                                   :is_transfered true
+                                                   :speak 1 :write 1 :listen 1 :read 1}
                                                   (select-keys registration-form-with-ssn person-fields))
                 result                     (yki-register/participant->csv-record (base/create-url-helper (str "localhost:" port)) {"5.4.3.2.1" "010199-9034"} participant)
-                csv-record                 ["5.4.3.2.1" "010199-9034" "Ankka" "Aku" "M" "FIN" "Katu 3" "12345" "Ankkalinna" "FIN" "aa@al.fi" "fi" "fi" 1]]
+                csv-record                 ["5.4.3.2.1" "010199-9034" "Ankka" "Aku" "M" "FIN" "Katu 3" "12345" "Ankkalinna" "FIN" "aa@al.fi" "fi" "fi" 1 1 1 1 1]]
             (is (= result csv-record)))))))
 
 (deftest create-participant-csv-line-missing-country-test
@@ -74,35 +199,99 @@
                                     (dissoc :gender))
               participant       (merge {:form          (apply dissoc registration-form person-fields)
                                         :person_oid    "5.4.3.2.1"
-                                        :is_transfered false}
+                                        :is_transfered false
+                                        :speak 1 :write 1 :listen 1 :read 1}
                                        (select-keys registration-form person-fields))
               result            (yki-register/participant->csv-record (base/create-url-helper (str "localhost:" port))
                                                                       {"5.4.3.2.1" "010199-9012"}
                                                                       participant)
-              csv-record        ["5.4.3.2.1" "010199-9012" "Ankka" "Aku" "M" "xxx" "Katu 3" "12345" "Ankkalinna" "xxx" "aa@al.fi" "fi" "fi" 0]]
+              csv-record        ["5.4.3.2.1" "010199-9012" "Ankka" "Aku" "M" "xxx" "Katu 3" "12345" "Ankkalinna" "xxx" "aa@al.fi" "fi" "fi" 0 1 1 1 1]]
           (is (= result csv-record)))))))
 
-(deftest delete-exam-session-and-organizer-test
-  (base/insert-base-data)
-  (testing "should send delete requests"
-    (with-routes!
-      {{:path "/oph/tutkintotilaisuus" :query-params {:kieli "fin" :taso "PT" :pvm "2018-01-27" :jarjestaja "1.2.3.4.5"}} {:status 202}
-       {:path "/oph/jarjestaja" :query-params {:oid "1.2.3.4"}}                                                           {:status 202}}
-      (let [exam-session-id          (:id (base/select-one "SELECT id FROM exam_session"))
-            db                       (base/db)
-            es                       (exam-session-db/get-exam-session-by-id db exam-session-id)
-            url-helper               (base/create-url-helper (str "localhost:" port))
-            delete-organizer-req     {:organizer-oid "1.2.3.4"
-                                      :type          "DELETE"
-                                      :created       (System/currentTimeMillis)}
-            delete-exam-session-req  {:exam-session es
-                                      :type         "DELETE"
-                                      :created      (System/currentTimeMillis)}
-            _delete-organizer-res    (yki-register/sync-exam-session-and-organizer db url-helper {:user "user" :password "pass"} false delete-organizer-req)
-            _delete-exam-session-res (yki-register/sync-exam-session-and-organizer db url-helper {:user "user" :password "pass"} false delete-exam-session-req)]
-        "tests that exception is not thrown"))))
+(deftest subtest-flags-in-csv-record-test
+  (with-routes! {}
+    (let [base-map {:form          {:gender "1" :nationalities nil :country_code nil
+                                    :birthdate "1990-06-15" :certificate_lang "fi" :exam_lang "fi"}
+                    :person_oid    "1.2.3.4.5"
+                    :is_transfered false
+                    :last_name "Mäkinen" :first_name "Matti" :email "m@m.fi"
+                    :zip "33100" :post_office "Tampere" :street_address "Linja 1" :country_code nil}
+          url-helper (base/create-url-helper (str "localhost:" port))
+          oid->ssn   {"1.2.3.4.5" "150690-900T"}]
+      (testing "READ_SPEAK/ALL_PARTS flags: speak=1 write=0 listen=0 read=1"
+        (let [result (yki-register/participant->csv-record url-helper oid->ssn
+                                                           (assoc base-map :speak 1 :write 0 :listen 0 :read 1))]
+          (is (= 1 (nth result 14)))
+          (is (= 0 (nth result 15)))
+          (is (= 0 (nth result 16)))
+          (is (= 1 (nth result 17)))))
+      (testing "LISTEN_WRITE/ALL_PARTS flags: speak=0 write=1 listen=1 read=0"
+        (let [result (yki-register/participant->csv-record url-helper oid->ssn
+                                                           (assoc base-map :speak 0 :write 1 :listen 1 :read 0))]
+          (is (= 0 (nth result 14)))
+          (is (= 1 (nth result 15)))
+          (is (= 1 (nth result 16)))
+          (is (= 0 (nth result 17)))))
+      (testing "single subtest SPEAK only: speak=1 rest=0"
+        (let [result (yki-register/participant->csv-record url-helper oid->ssn
+                                                           (assoc base-map :speak 1 :write 0 :listen 0 :read 0))]
+          (is (= 1 (nth result 14)))
+          (is (= 0 (nth result 15)))
+          (is (= 0 (nth result 16)))
+          (is (= 0 (nth result 17))))))))
 
-(def csv (str/join (System/lineSeparator) ["5.4.3.2.2;301079-900U;Ankka;Iines;N;FIN;Katu 4;12346;Ankkalinna;FIN;aa@al.fi;fi;fi;0" "5.4.3.2.1;010199-9012;Ankka;Aku;M;xxx;Katu 3;12345;Ankkalinna;FIN;aa@al.fi;fi;fi;0" "5.4.3.2.4;301079-083N;Ankka;Roope;M;FIN;Katu 5;12346;Ankkalinna;FIN;roope@al.fi;fi;fi;0"]))
+;; ──────────────────────────────────────────────────────────────────────────────
+;; create-participants-csv — end-to-end with mixed session types
+;; ──────────────────────────────────────────────────────────────────────────────
+
+(deftest create-participants-csv-mixed-session-types-test
+  (with-routes! {}
+    (let [url-helper (base/create-url-helper (str "localhost:" port))
+          oid->ssn   {"p1" "" "p2" "" "p3" "" "p4" "" "p5" ""}
+          make-row   (fn [oid session-type partial-type]
+                       {:person_oid     oid
+                        :exam_session_type session-type
+                        :partial_exam_type partial-type
+                        :is_transfered  false
+                        :last_name      "Testi" :first_name "Henkilö"
+                        :email          "t@test.fi" :zip "00100"
+                        :post_office    "Helsinki" :street_address "Tie 1" :country_code nil
+                        :form           {:gender nil :nationalities nil
+                                         :birthdate "2000-01-01"
+                                         :certificate_lang "fi" :exam_lang "fi"}})
+          participants [(make-row "p1" "FULL"         "ALL_PARTS")   ; → 1 1 1 1
+                        (make-row "p2" "READ_SPEAK"   "ALL_PARTS")   ; → 1 0 0 1
+                        (make-row "p3" "LISTEN_WRITE" "ALL_PARTS")   ; → 0 1 1 0
+                        (make-row "p4" "READ_SPEAK"   "ALL_PARTS")   ; \  merged
+                        (make-row "p4" "LISTEN_WRITE" "ALL_PARTS")   ; /  → 1 1 1 1
+                        (make-row "p5" "READ_SPEAK"   "SPEAK")       ; \  merged
+                        (make-row "p5" "LISTEN_WRITE" "LISTEN")]     ; /  → 1 0 1 0
+          csv-str (yki-register/create-participants-csv url-helper participants oid->ssn)
+          rows    (str/split csv-str #"\n")
+          fields  (fn [row-str] (str/split row-str #";"))]
+      (testing "five distinct persons in output (p4 and p5 are merged)"
+        (is (= 5 (count rows))))
+      (testing "p1 FULL/ALL_PARTS → speak=1 write=1 listen=1 read=1"
+        (let [f (fields (first (filter #(str/starts-with? % "p1") rows)))]
+          (is (= ["1" "1" "1" "1"] (subvec (vec f) 14 18)))))
+      (testing "p2 READ_SPEAK/ALL_PARTS → speak=1 write=0 listen=0 read=1"
+        (let [f (fields (first (filter #(str/starts-with? % "p2") rows)))]
+          (is (= ["1" "0" "0" "1"] (subvec (vec f) 14 18)))))
+      (testing "p3 LISTEN_WRITE/ALL_PARTS → speak=0 write=1 listen=1 read=0"
+        (let [f (fields (first (filter #(str/starts-with? % "p3") rows)))]
+          (is (= ["0" "1" "1" "0"] (subvec (vec f) 14 18)))))
+      (testing "p4 READ_SPEAK+LISTEN_WRITE both ALL_PARTS → merged speak=1 write=1 listen=1 read=1"
+        (let [f (fields (first (filter #(str/starts-with? % "p4") rows)))]
+          (is (= ["1" "1" "1" "1"] (subvec (vec f) 14 18)))))
+      (testing "p5 READ_SPEAK/SPEAK + LISTEN_WRITE/LISTEN → merged speak=1 write=0 listen=1 read=0"
+        (let [f (fields (first (filter #(str/starts-with? % "p5") rows)))]
+          (is (= ["1" "0" "1" "0"] (subvec (vec f) 14 18))))))))
+
+;; ──────────────────────────────────────────────────────────────────────────────
+;; sync-exam-session-participants — full integration against embedded DB
+;; ──────────────────────────────────────────────────────────────────────────────
+
+(def csv (str/join (System/lineSeparator) ["5.4.3.2.2;301079-900U;Ankka;Iines;N;FIN;Katu 4;12346;Ankkalinna;FIN;aa@al.fi;fi;fi;0;1;1;1;1" "5.4.3.2.1;010199-9012;Ankka;Aku;M;xxx;Katu 3;12345;Ankkalinna;FIN;aa@al.fi;fi;fi;0;1;1;1;1" "5.4.3.2.4;301079-083N;Ankka;Roope;M;FIN;Katu 5;12346;Ankkalinna;FIN;roope@al.fi;fi;fi;0;1;1;1;1"]))
 
 (deftest sync-exam-session-participants-test
   (base/insert-base-data)

--- a/test/yki/job/scheduled_tasks_test.clj
+++ b/test/yki/job/scheduled_tasks_test.clj
@@ -150,6 +150,7 @@
 (deftest handle-exam-session-participants-sync-test
   (base/insert-base-data)
   (base/insert-registrations "COMPLETED")
+  (jdbc/execute! @embedded-db/conn "UPDATE exam_session SET last_sync_at = NOW()")
   (jdbc/execute! @embedded-db/conn (str "UPDATE exam_date set exam_date = '" (base/two-weeks-from-now) "'"))
   (with-routes!
     {"/oph/osallistujat"                                                    {:status 200
@@ -177,7 +178,7 @@
 (deftest handle-exam-session-participants-failure-test
   (base/insert-base-data)
   (base/insert-registrations "COMPLETED")
-
+  (jdbc/execute! @embedded-db/conn "UPDATE exam_session SET last_sync_at = NOW()")
   (jdbc/execute! @embedded-db/conn (str "UPDATE exam_date set registration_end_date = '" (base/two-weeks-ago) "'"))
   (jdbc/execute! @embedded-db/conn (str "INSERT INTO participant_sync_status (exam_session_id, failed_at) VALUES (1, '" (base/yesterday) "')"))
 


### PR DESCRIPTION
Mahdollistetaan osakokeistettujen tutkintotilaisuuksien ilmoittautumisten siirto Solki-järjestelmään.

Solki-järjestelmään lähetetään CSV-tiedosto, jossa on merkattuna ilmoittatuneen henkilön osakoevalinnat seuraavasti:
-osallistuuko henkilö puhumisen osakokeeseen (1, jos osallistuu, muuten 0)
-osallistuuko henkilö kirjoittamisen osakokeeseen (1, jos osallistuu, muuten 0)
-osallistuuko henkilö tekstin ymmärtämisen osakokeeseen (1, jos osallistuu, muuten 0)
-osallistuuko henkilö puheen ymmärtämisen osakokeeseen (1, jos osallistuu, muuten 0)

Tässä PR:ssä myös mukana uusi eräajo, joka lähettää Solki-järjestelmään uuden virkailijan kautta luodut tutkintotilaisuudet.