### PR TITLE
OPHKIOS-369 osakoeilmonputken korjauksia

### DIFF
--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -481,6 +481,8 @@ SELECT
   e.max_participants,
   e.max_participants_read_listen,
   e.max_participants_speak_write,
+  e.start_time_read_listen,
+  e.start_time_speak_write,
   e.office_oid,
   e.published_at,
   e.type,

--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -917,6 +917,7 @@ WHERE re.state = 'STARTED'
 SELECT re.id, re.kind, re.partial_exam_type, re.exam_session_id
 FROM registration re
 WHERE re.id = :id
+  AND re.participant_id = :participant-id
   AND re.state IN ('STARTED', 'SUBMITTED');
 
 -- name: select-registration

--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -344,15 +344,17 @@ SELECT
   (SELECT COUNT(1)
    FROM registration re
    WHERE re.exam_session_id = e.id
-     AND re.partial_exam_type IN ('ALL_PARTS', 'READ', 'LISTEN')
      AND re.kind = 'ADMISSION'
-     AND re.state IN ('COMPLETED', 'SUBMITTED', 'STARTED')) AS participants_read_listen,
+     AND re.state IN ('COMPLETED', 'SUBMITTED', 'STARTED')
+     AND ((e.type = 'READ_SPEAK' AND re.partial_exam_type IN ('ALL_PARTS', 'READ'))
+          OR (e.type = 'LISTEN_WRITE' AND re.partial_exam_type IN ('ALL_PARTS', 'LISTEN')))) AS participants_read_listen,
   (SELECT COUNT(1)
    FROM registration re
    WHERE re.exam_session_id = e.id
      AND re.kind = 'ADMISSION'
-     AND re.partial_exam_type IN ('ALL_PARTS', 'SPEAK', 'WRITE')
-     AND re.state IN ('COMPLETED', 'SUBMITTED', 'STARTED')) AS participants_speak_write,
+     AND re.state IN ('COMPLETED', 'SUBMITTED', 'STARTED')
+     AND ((e.type = 'READ_SPEAK' AND re.partial_exam_type IN ('ALL_PARTS', 'SPEAK'))
+          OR (e.type = 'LISTEN_WRITE' AND re.partial_exam_type IN ('ALL_PARTS', 'WRITE')))) AS participants_speak_write,
   o.oid AS organizer_oid,
   (SELECT array_to_json(array_agg(loc))
    FROM (SELECT
@@ -477,6 +479,8 @@ SELECT
   e.language_code,
   e.level_code,
   e.max_participants,
+  e.max_participants_read_listen,
+  e.max_participants_speak_write,
   e.office_oid,
   e.published_at,
   e.type,
@@ -490,6 +494,20 @@ SELECT
  WHERE re.exam_session_id = e.id
    AND re.kind = 'ADMISSION'
    AND re.state IN ('COMPLETED', 'SUBMITTED', 'STARTED')) AS participants,
+(SELECT COUNT(1)
+ FROM registration re
+ WHERE re.exam_session_id = e.id
+   AND re.kind = 'ADMISSION'
+   AND re.state IN ('COMPLETED', 'SUBMITTED', 'STARTED')
+   AND ((e.type = 'READ_SPEAK' AND re.partial_exam_type IN ('ALL_PARTS', 'READ'))
+        OR (e.type = 'LISTEN_WRITE' AND re.partial_exam_type IN ('ALL_PARTS', 'LISTEN')))) AS participants_read_listen,
+(SELECT COUNT(1)
+ FROM registration re
+ WHERE re.exam_session_id = e.id
+   AND re.kind = 'ADMISSION'
+   AND re.state IN ('COMPLETED', 'SUBMITTED', 'STARTED')
+   AND ((e.type = 'READ_SPEAK' AND re.partial_exam_type IN ('ALL_PARTS', 'SPEAK'))
+        OR (e.type = 'LISTEN_WRITE' AND re.partial_exam_type IN ('ALL_PARTS', 'WRITE')))) AS participants_speak_write,
 (SELECT COUNT(1)
  FROM registration re
  WHERE re.exam_session_id = e.id

--- a/src/yki/boundary/registration_db.clj
+++ b/src/yki/boundary/registration_db.clj
@@ -51,7 +51,7 @@
   (expire-queued-registrations-after-exam-date! [db])
   (get-free-registration [db registration-id])
   (check-registration-id-matches-session [db registration-id participant-id external-user-id])
-  (get-registration-details-by-id [db registration-id]))
+  (get-registration-details-by-id [db registration-id participant-id]))
 
 (defn get-registration-data-with-tx
   [tx registration-id participant-id lang]
@@ -273,5 +273,5 @@
     [{:keys [spec]} registration-id participant-id external-user-id]
     (first (q/check-registration-id-matches-session spec {:id registration-id :participant_id participant-id :external_user_id external-user-id})))
   (get-registration-details-by-id
-    [{:keys [spec]} registration-id]
-    (first (q/select-registration-details-by-id spec {:id registration-id}))))
+    [{:keys [spec]} registration-id participant-id]
+    (first (q/select-registration-details-by-id spec {:id registration-id :participant-id participant-id}))))

--- a/src/yki/handler/registration.clj
+++ b/src/yki/handler/registration.clj
@@ -46,11 +46,14 @@
                                             registration-identify
                                             (:payment-config payment-helper)))
       (context "/:id" []
-        (GET "/" _
+        (GET "/" request
           :path-params [id :- ::ys/id]
-          (if-let [result (registration-db/get-registration-details-by-id db id)]
-            (ok result)
-            (not-found {:error "Registration not found"})))
+          (let [session            (:session request)
+                {:keys [identity]} session
+                participant-id     (registration/get-participant-id db identity)]
+            (if-let [result (registration-db/get-registration-details-by-id db id participant-id)]
+              (ok result)
+              (not-found {:error "Registration not found"}))))
         (POST "/submit" request
           :body [registration ::ys/registration]
           :path-params [id :- ::ys/id]

--- a/test/resources/init_registration_response.json
+++ b/test/resources/init_registration_response.json
@@ -14,6 +14,8 @@
     "max_participants": 5,
     "max_participants_read_listen": null,
     "max_participants_speak_write": null,
+    "start_time_read_listen": null,
+    "start_time_speak_write": null,
     "participants_read_listen": 0,
     "participants_speak_write": 0,
     "pa_participants": 0,

--- a/test/resources/init_registration_response.json
+++ b/test/resources/init_registration_response.json
@@ -12,6 +12,10 @@
       "ALL_PARTS": "ADMISSION"
     },
     "max_participants": 5,
+    "max_participants_read_listen": null,
+    "max_participants_speak_write": null,
+    "participants_read_listen": 0,
+    "participants_speak_write": 0,
     "pa_participants": 0,
     "language_code": "fin",
     "office_oid": "1.2.3.4.5",


### PR DESCRIPTION
LIsätty puuttuvia arvoja:

- participants_read_listen
- participants_speak_write
- max_participants_read_listen
- max_participants_speak_write
- start_time_read_listen
- start_time_speak_write

Alunperin oli myös start_time joka koskee koetilaisuuksia tyyppiä "FULL". Näistä todettiin weeklyssä, ettei ole tarvetta eivätkä järjestäjät pysty näihin ajankohtaa laittamaan. Nämä on poistettu frontista mutta voisi depkrikoida myös bäkkäriltä niin ei turhaan valu responseen.

