### PR TITLE
Sähköposti osakoekorjaus & registration get rajapinta

### DIFF
--- a/resources/yki/queries.sql
+++ b/resources/yki/queries.sql
@@ -1062,13 +1062,11 @@ WHERE re.id = :id
          AND reg.state = 'STARTED'
          AND reg.exam_session_id = es.id);
 
--- name: select-partial-exam-type-by-participant-and-session
+-- name: select-partial-exam-type-by-registration-id
 SELECT re.partial_exam_type
 FROM registration re
-WHERE re.participant_id = :participant_id
-  AND re.exam_session_id = :exam_session_id
-  AND re.state = 'STARTED'
-LIMIT 1;
+WHERE re.id = :registration_id
+  AND re.exam_session_id = :exam_session_id;
 
 -- name: select-completed-registration-details
 SELECT re.state,

--- a/src/yki/boundary/registration_db.clj
+++ b/src/yki/boundary/registration_db.clj
@@ -57,12 +57,13 @@
   [tx registration-id participant-id lang]
   (first (q/select-registration-data tx {:id registration-id :participant_id participant-id :lang lang})))
 
-(defn get-partial-exam-type-for-login [db participant-id exam-session-id]
-  (:partial_exam_type
-    (first (q/select-partial-exam-type-by-participant-and-session
-             (:spec db)
-             {:participant_id  participant-id
-              :exam_session_id exam-session-id}))))
+(defn get-partial-exam-type-for-login [db registration-id exam-session-id]
+  (when registration-id
+    (:partial_exam_type
+      (first (q/select-partial-exam-type-by-registration-id
+               (:spec db)
+               {:registration_id registration-id
+                :exam_session_id exam-session-id})))))
 
 (defn- expire-registrations! [tx ids]
   (when (seq ids)

--- a/src/yki/handler/login_link.clj
+++ b/src/yki/handler/login_link.clj
@@ -78,9 +78,9 @@
                   registration-matches     (registration-db/check-registration-id-matches-session db registration-id participant-id (:yki-session-id session))
                   to-queue?                (= "QUEUE" registration-kind)
                   registration-url         (cond
-                                              (and to-queue? registration-id) (url-helper :yki-ui.exam-session-queue.url exam-session-id registration-id)
-                                              registration-id                 (url-helper :yki-ui.exam-session-registration.url exam-session-id registration-id)
-                                              :else                           (url-helper :exam-session.url exam-session-id))
+                                             (and to-queue? registration-id) (url-helper :yki-ui.exam-session-queue.url exam-session-id registration-id)
+                                             registration-id                 (url-helper :yki-ui.exam-session-registration.url exam-session-id registration-id)
+                                             :else                           (url-helper :exam-session.url exam-session-id))
                   registration-expired-url (url-helper :yki-ui.exam-session-registration-expired.url exam-session-id)
                   link                     (assoc login-link :participant_id participant-id
                                                   :type "LOGIN"

--- a/src/yki/handler/login_link.clj
+++ b/src/yki/handler/login_link.clj
@@ -28,7 +28,7 @@
         link-type         (if to-queue? "LOGIN_QUEUE" (:type login-link))
         subject           (str (localisation/get-translation lang (if to-queue? "email.login_queue.subject" "email.login.subject")))
         hashed            (sha256-hash code)
-        partial-exam-type (registration-db/get-partial-exam-type-for-login db (:participant_id login-link) (:exam_session_id login-link))
+        partial-exam-type (registration-db/get-partial-exam-type-for-login db (:registration_id login-link) (:exam_session_id login-link))
         template-data     (assoc exam-session :subject subject
                                  :language (template-util/get-language (:language_code exam-session) lang)
                                  :level (template-util/get-level (:level_code exam-session) lang)
@@ -77,7 +77,10 @@
                   registration-id          (:registration_id login-link)
                   registration-matches     (registration-db/check-registration-id-matches-session db registration-id participant-id (:yki-session-id session))
                   to-queue?                (= "QUEUE" registration-kind)
-                  registration-url         (url-helper (if to-queue? :yki-ui.exam-session-queue.url :yki-ui.exam-session-registration.url) exam-session-id registration-id)
+                  registration-url         (cond
+                                              (and to-queue? registration-id) (url-helper :yki-ui.exam-session-queue.url exam-session-id registration-id)
+                                              registration-id                 (url-helper :yki-ui.exam-session-registration.url exam-session-id registration-id)
+                                              :else                           (url-helper :exam-session.url exam-session-id))
                   registration-expired-url (url-helper :yki-ui.exam-session-registration-expired.url exam-session-id)
                   link                     (assoc login-link :participant_id participant-id
                                                   :type "LOGIN"

--- a/src/yki/middleware/auth.clj
+++ b/src/yki/middleware/auth.clj
@@ -202,7 +202,7 @@
      {:pattern #".*/api/registration/init"
       :handler any-access}
      {:pattern        #".*/api/registration/.*"
-      :request-method :delete
+      :request-method #{:get :delete}
       :handler        {:or [oppija-authenticated? session-authenticated?]}}
      {:pattern #".*/api/registration.*"
       :handler oppija-authenticated?}

--- a/test/yki/handler/login_link_test.clj
+++ b/test/yki/handler/login_link_test.clj
@@ -63,7 +63,7 @@
         (base/execute! "INSERT INTO participant (external_user_id, email) VALUES ('partial@test.com', 'partial@test.com');")
         (let [participant-id  (:id (base/select-one "SELECT id FROM participant WHERE external_user_id = 'partial@test.com'"))
               _               (base/execute! (str "INSERT INTO registration (participant_id, exam_session_id, state, kind, partial_exam_type) VALUES ("
-                                                   participant-id ", 1, 'STARTED', 'ADMISSION', 'SPEAK');"))
+                                                  participant-id ", 1, 'STARTED', 'ADMISSION', 'SPEAK');"))
               registration-id (:id (base/select-one (str "SELECT id FROM registration WHERE participant_id = " participant-id)))
               request-data    {:email           "partial@test.com"
                                :exam_session_id 1

--- a/test/yki/handler/login_link_test.clj
+++ b/test/yki/handler/login_link_test.clj
@@ -2,6 +2,7 @@
   (:require
     [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
     [clojure.java.jdbc :as jdbc]
+    [clojure.string :as s]
     [duct.database.sql]
     [integrant.core :as ig]
     [jsonista.core :as j]
@@ -52,11 +53,28 @@
               _                (base/body-as-json response)
               email-request    (pgq/take email-q)]
           (is (= (count code) 64))
-          (is (= success-redirect (str "http://yki.localhost:" port "/yki/ilmoittautuminen/tutkintotilaisuus/1/")))
+          (is (= success-redirect (str "http://yki.localhost:" port "/yki/tutkintotilaisuus/1")))
           (is (= (:status response) 200))
           (testing "email send request should be send to job queue"
             (is (= (:subject email-request) "Ilmoittautuminen (YKI): Suomi perustaso - Omenia, 27.1.2018"))
             (is (= (:recipients email-request) ["test@test.com"])))))
+      (testing "login link for an existing partial exam registration should list only the chosen subtest"
+        (base/execute! "UPDATE exam_session SET type = 'READ_SPEAK' WHERE id = 1;")
+        (base/execute! "INSERT INTO participant (external_user_id, email) VALUES ('partial@test.com', 'partial@test.com');")
+        (let [participant-id  (:id (base/select-one "SELECT id FROM participant WHERE external_user_id = 'partial@test.com'"))
+              _               (base/execute! (str "INSERT INTO registration (participant_id, exam_session_id, state, kind, partial_exam_type) VALUES ("
+                                                   participant-id ", 1, 'STARTED', 'ADMISSION', 'SPEAK');"))
+              registration-id (:id (base/select-one (str "SELECT id FROM registration WHERE participant_id = " participant-id)))
+              request-data    {:email           "partial@test.com"
+                               :exam_session_id 1
+                               :registration_id registration-id}
+              response        (request-link! request-data)
+              success-redirect (:success_redirect (base/select-one (str "SELECT * FROM login_link WHERE registration_id = " registration-id)))
+              email-request   (pgq/take email-q)]
+          (is (= (:status response) 200))
+          (is (= success-redirect (str "http://yki.localhost:" port "/yki/ilmoittautuminen/tutkintotilaisuus/1/" registration-id)))
+          (is (s/includes? (:body email-request) "Puhuminen"))
+          (is (not (s/includes? (:body email-request) "Tekstin ymmärtäminen")))))
       (testing "login link should not be created if exam session isn't open for registration"
         (base/execute! "UPDATE exam_date SET registration_start_date='2039-01-01' WHERE id IN (SELECT exam_date_id FROM exam_session WHERE id=1);")
         (let [request-data  {:email           "unique@email.com"

--- a/test/yki/util/template_util_test.clj
+++ b/test/yki/util/template_util_test.clj
@@ -78,6 +78,17 @@
         (is (s/includes? rendered "Email address: foo@bar"))
         (is (s/includes? rendered "Phone: +358123"))))))
 
+(deftest get-registration-subtests-test
+  (testing "returns only the chosen subtest for a partial exam registration"
+    (is (= ["Puhuminen"] (template-util/get-registration-subtests "READ_SPEAK" "SPEAK" "fi")))
+    (is (= ["Kirjoittaminen"] (template-util/get-registration-subtests "LISTEN_WRITE" "WRITE" "fi"))))
+  (testing "falls back to every subtest of the session type when the partial exam type is unknown"
+    (is (= ["Puhuminen" "Tekstin ymmärtäminen"] (template-util/get-registration-subtests "READ_SPEAK" nil "fi")))
+    (is (= ["Puheen ymmärtäminen" "Kirjoittaminen"] (template-util/get-registration-subtests "LISTEN_WRITE" nil "fi"))))
+  (testing "returns all four subtests for a full exam"
+    (is (= ["Puheen ymmärtäminen" "Puhuminen" "Tekstin ymmärtäminen" "Kirjoittaminen"]
+           (template-util/get-registration-subtests "FULL" nil "fi")))))
+
 (deftest render-evaluation-payment-success-email-test
   (let [template "EVALUATION_PAYMENT_SUCCESS"
         lang     "fi"


### PR DESCRIPTION
Haetaan osakokeeet `registration-id`:llä eikä `participant_id` & `exam_session_id` sähköpostiviesteihin.